### PR TITLE
fix: use ast_merge for proper three-way merge content

### DIFF
--- a/crates/dk-engine/src/workspace/conflict.rs
+++ b/crates/dk-engine/src/workspace/conflict.rs
@@ -85,9 +85,12 @@ pub fn analyze_file_conflict(
                         // only fire when the merge result is smaller than even the
                         // most-deleting agent's output, which is a strong signal that
                         // ast_merge dropped content it shouldn't have.
+                        // Note: uses `merged * 5 < min * 4` instead of
+                        // `merged * 100 / min < 80` to avoid usize overflow on
+                        // large files (>42 MB on 32-bit hosts).
                         let merged_len = result.merged_content.len();
                         let min_agent_len = head.len().min(overlay.len());
-                        if min_agent_len > 0 && merged_len * 100 / min_agent_len < 80 {
+                        if min_agent_len > 0 && merged_len * 5 < min_agent_len * 4 {
                             byte_level_analysis(
                                 file_path,
                                 base_content,


### PR DESCRIPTION
## Summary

- Wires the existing `ast_merge` function into `analyze_file_conflict` for the rebase path
- When two agents edit different functions in the same file, the merged content now includes BOTH agents' changes instead of only the second agent's
- True conflicts (same symbol modified by both) are still detected and reported
- Falls back to byte-level comparison for unsupported languages

## Context

Found during comprehensive E2E testing: when Agent A modifies `hash_password()` and Agent B modifies `generate_token()`, the "auto-merge" returned only B's file content, silently dropping A's changes. The `ast_merge` function that properly combines symbol-level changes existed but wasn't wired into the rebase path.

## Test plan

- [ ] E2E: two agents modify different functions in same file — both changes preserved
- [ ] E2E: two agents modify same function — conflict correctly detected
- [ ] Existing conflict/merge unit tests pass (12/12)
- [ ] Verify import deduplication works (both agents add same import)