### PR TITLE
fix: change SymbolOverwrite.merged_at from Timestamp to string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,7 +834,6 @@ dependencies = [
  "dk-runner",
  "jsonwebtoken",
  "prost",
- "prost-types",
  "redis",
  "serde",
  "serde_json",

--- a/crates/dk-cli/src/commands/agent.rs
+++ b/crates/dk-cli/src/commands/agent.rs
@@ -482,11 +482,11 @@ async fn merge_cmd(
                 w.overwrites.len()
             );
             for o in &w.overwrites {
-                let merged_at = o
-                    .merged_at
-                    .as_ref()
-                    .map(|t| t.to_string())
-                    .unwrap_or_else(|| "unknown".to_string());
+                let merged_at = if o.merged_at.is_empty() {
+                    "unknown".to_string()
+                } else {
+                    o.merged_at.clone()
+                };
                 eprintln!(
                     "  {} {} in {} (by {}, merged at {})",
                     "overwrite:".yellow(),

--- a/crates/dk-cli/src/commands/session_push.rs
+++ b/crates/dk-cli/src/commands/session_push.rs
@@ -91,7 +91,7 @@ pub async fn run(out: Output, message: Option<&str>, force: bool) -> Result<()> 
                             "symbol_name": o.symbol_name,
                             "other_agent": o.other_agent,
                             "other_changeset_id": o.other_changeset_id,
-                            "merged_at": o.merged_at.as_ref().map(|t| t.to_string()).unwrap_or_else(|| "unknown".to_string()),
+                            "merged_at": if o.merged_at.is_empty() { "unknown" } else { &o.merged_at },
                         })
                     }).collect::<Vec<_>>(),
                 }));
@@ -102,11 +102,11 @@ pub async fn run(out: Output, message: Option<&str>, force: bool) -> Result<()> 
                     w.overwrites.len()
                 );
                 for o in &w.overwrites {
-                    let merged_at = o
-                        .merged_at
-                        .as_ref()
-                        .map(|t| t.to_string())
-                        .unwrap_or_else(|| "unknown".to_string());
+                    let merged_at = if o.merged_at.is_empty() {
+                        "unknown".to_string()
+                    } else {
+                        o.merged_at.clone()
+                    };
                     eprintln!(
                         "  {} {} in {} (by {}, merged at {})",
                         "overwrite:".yellow(),

--- a/crates/dk-protocol/Cargo.toml
+++ b/crates/dk-protocol/Cargo.toml
@@ -21,7 +21,6 @@ uuid.workspace = true
 dashmap = "6"
 tonic = "0.12"
 prost = "0.13"
-prost-types = "0.13"
 tokio-stream = "0.1"
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/dk-protocol/proto/dkod/v1/agent.proto
+++ b/crates/dk-protocol/proto/dkod/v1/agent.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 package dkod.v1;
 
-import "google/protobuf/timestamp.proto";
 import "dkod/v1/types.proto";
 
 service AgentService {
@@ -269,7 +268,7 @@ message SymbolOverwrite {
   string symbol_name = 2;
   string other_agent = 3;
   string other_changeset_id = 4;
-  google.protobuf.Timestamp merged_at = 5;
+  string merged_at = 5;
 }
 
 // --- WATCH ---

--- a/proto/dkod/v1/agent.proto
+++ b/proto/dkod/v1/agent.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 package dkod.v1;
 
-import "google/protobuf/timestamp.proto";
 import "dkod/v1/types.proto";
 
 service AgentService {
@@ -269,7 +268,7 @@ message SymbolOverwrite {
   string symbol_name = 2;
   string other_agent = 3;
   string other_changeset_id = 4;
-  google.protobuf.Timestamp merged_at = 5;
+  string merged_at = 5;
 }
 
 // --- WATCH ---


### PR DESCRIPTION
## Summary
- Change `SymbolOverwrite.merged_at` from `google.protobuf.Timestamp` to `string` (RFC 3339) in both proto files
- Remove `google/protobuf/timestamp.proto` import (no longer needed)
- Remove `prost-types` dependency from dk-protocol
- Update CLI code in agent.rs and session_push.rs to handle string field instead of Timestamp

Fixes protobuf encoding mismatch when platform sends string timestamps.