### PR TITLE
fix: delete callee edges before symbol removal during re-index

### DIFF
--- a/crates/dk-engine/src/graph/callgraph.rs
+++ b/crates/dk-engine/src/graph/callgraph.rs
@@ -108,9 +108,12 @@ impl CallGraphStore {
         Ok(rows.into_iter().map(CallEdgeRow::into_call_edge).collect())
     }
 
-    /// Delete all call edges where the caller symbol is in the given file.
-    /// This joins on the `symbols` table to resolve the caller's file path.
-    /// Returns the number of rows deleted.
+    /// Delete all call edges where any involved symbol is in the given file.
+    /// This deletes edges where the file's symbols appear as either caller OR
+    /// callee, which is required before deleting the symbols themselves —
+    /// otherwise the `call_edges_callee_id_fkey` FK constraint blocks the
+    /// symbol deletion.
+    /// Returns the total number of rows deleted.
     pub async fn delete_edges_for_file(
         &self,
         repo_id: RepoId,
@@ -120,7 +123,7 @@ impl CallGraphStore {
             r#"
             DELETE FROM call_edges ce
             USING symbols s
-            WHERE ce.caller_id = s.id
+            WHERE (ce.caller_id = s.id OR ce.callee_id = s.id)
               AND s.repo_id = $1
               AND s.file_path = $2
             "#,


### PR DESCRIPTION
## Summary
- Fixed FK constraint violation (`call_edges_callee_id_fkey`) during file re-indexing in SUBMIT
- `delete_edges_for_file` now removes edges where the file's symbols appear as either caller OR callee
- This was blocking all TypeScript SUBMIT operations in repos with cross-file call edges (e.g. `main.test.ts` importing from `main.ts`)

## Root Cause
When re-indexing a file, `delete_edges_for_file` only removed `call_edges` rows where the file's symbols were the **caller** (`ce.caller_id = s.id`). Edges where the file's symbols were the **callee** (referenced by functions in other files) remained in the table. The subsequent `delete_by_file` then tried to remove the symbol rows, but the remaining callee references caused the FK constraint violation.

## Fix
Extended the DELETE query to also match `ce.callee_id = s.id`:
```sql
WHERE (ce.caller_id = s.id OR ce.callee_id = s.id)
```

## Test plan
- [ ] Existing unit tests pass (DB-dependent integration tests require `dkod_test` database)
- [ ] E2E: SUBMIT for TypeScript files in `dkod-e2e-testbed` should succeed after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)