### PR TITLE
feat(engine): add Engine::with_cache() constructor

### DIFF
--- a/crates/dk-engine/src/repo.rs
+++ b/crates/dk-engine/src/repo.rs
@@ -66,10 +66,9 @@ impl Engine {
 
     /// Create a new Engine with an explicit workspace cache implementation.
     ///
-    /// Identical to [`Engine::new`] but uses
-    /// [`WorkspaceManager::with_cache`] instead of the default no-op cache.
-    /// Pass `Arc::new(NoOpCache)` to opt-out of caching, or provide a
-    /// `ValkeyCache` for multi-pod deployments.
+    /// This is the primary constructor. [`Engine::new`] delegates here with
+    /// [`NoOpCache`]. Pass a `ValkeyCache` (or any [`WorkspaceCache`] impl)
+    /// for multi-pod deployments.
     pub fn with_cache(
         storage_path: PathBuf,
         db: PgPool,


### PR DESCRIPTION
## Summary
- Add `Engine::with_cache(storage_path, db, cache)` constructor that injects a `WorkspaceCache` into the Engine at construction time
- Required for multi-pod platform deployments where dk-server needs to pass a ValkeyCache to the workspace manager

## Test plan
- [x] `cargo check -p dk-engine` passes
- [ ] CI check/clippy/test passes