### PR TITLE
feat(protocol): add Approve RPC

### DIFF
--- a/crates/dk-protocol/proto/dkod/v1/agent.proto
+++ b/crates/dk-protocol/proto/dkod/v1/agent.proto
@@ -30,6 +30,9 @@ service AgentService {
 
   // Push merged changes to GitHub (branch or PR)
   rpc Push(PushRequest) returns (PushResponse);
+
+  // Approve a submitted changeset (platform-level state transition)
+  rpc Approve(ApproveRequest) returns (ApproveResponse);
 }
 
 // ── CONNECT ──
@@ -417,4 +420,17 @@ message PushResponse {
   string pr_url = 2;         // empty when mode = PUSH_MODE_BRANCH
   string commit_hash = 3;
   repeated string changeset_ids = 4;  // changesets included in the push
+}
+
+// --- APPROVE ---
+
+message ApproveRequest {
+  string session_id = 1;
+}
+
+message ApproveResponse {
+  bool success = 1;
+  string changeset_id = 2;
+  string new_state = 3;      // e.g. "approved"
+  string message = 4;        // human-readable status message
 }

--- a/crates/dk-protocol/src/server.rs
+++ b/crates/dk-protocol/src/server.rs
@@ -195,4 +195,13 @@ impl crate::agent_service_server::AgentService for ProtocolServer {
         let resp = crate::push::handle_push(self, request.into_inner()).await?;
         Ok(Response::new(resp))
     }
+
+    async fn approve(
+        &self,
+        _request: Request<crate::ApproveRequest>,
+    ) -> Result<Response<crate::ApproveResponse>, Status> {
+        Err(Status::unimplemented(
+            "approve is a platform-level operation; use the managed server",
+        ))
+    }
 }


### PR DESCRIPTION
## Summary
- Add `rpc Approve(ApproveRequest) returns (ApproveResponse)` to `AgentService`
- Engine returns `UNIMPLEMENTED` — the real logic lives in the platform's `AuthenticatedAgentService`
- Needed so dk_approve MCP tool can use gRPC (like all other dk_* tools) instead of HTTP REST which fails with 401

## Test plan
- [x] `cargo check --workspace` passes
- Platform PR will implement the handler and update the MCP client