### PR TITLE
fix(merge): preserve inline comments and fix variable spacing in AST merge

### DIFF
--- a/crates/dk-engine/src/conflict/ast_merge.rs
+++ b/crates/dk-engine/src/conflict/ast_merge.rs
@@ -103,7 +103,26 @@ fn extract_spans(
         let start = sym.span.start_byte as usize;
         let end = sym.span.end_byte as usize;
         if end <= bytes.len() {
-            let body = String::from_utf8_lossy(&bytes[start..end]).to_string();
+            // Extend the body to include any trailing inline comment on the
+            // same line (tree-sitter Python places `# comment` as a sibling
+            // node after the expression_statement, so end_byte stops before it).
+            let extended_end = if end < bytes.len() {
+                let rest = &source[end..];
+                if let Some(nl) = rest.find('\n') {
+                    let trailing = rest[..nl].trim();
+                    if trailing.starts_with('#') || trailing.is_empty() {
+                        // Include inline comment or whitespace up to newline
+                        end + nl
+                    } else {
+                        end
+                    }
+                } else {
+                    source.len() // last line, no trailing newline
+                }
+            } else {
+                end
+            };
+            let body = String::from_utf8_lossy(&bytes[start..extended_end]).to_string();
             // Only prepend when the doc text is outside the symbol byte span.
             // TypeScript stores the full "// …" text as a sibling; Rust strips
             // the "///" prefix; Python embeds the docstring inside the body.
@@ -374,9 +393,21 @@ pub fn ast_merge(
         output.push('\n');
     }
 
-    // Then symbols, joined with double newlines
-    let symbol_texts: Vec<&str> = merged_symbols.iter().map(|s| s.text.as_str()).collect();
-    output.push_str(&symbol_texts.join("\n\n"));
+    // Join symbols with context-aware spacing:
+    // - Double newline (\n\n) before/after functions and classes
+    // - Single newline (\n) between consecutive variables
+    for (i, sym) in merged_symbols.iter().enumerate() {
+        if i > 0 {
+            let prev_is_var = merged_symbols[i - 1].kind == "variable";
+            let curr_is_var = sym.kind == "variable";
+            if prev_is_var && curr_is_var {
+                output.push('\n');
+            } else {
+                output.push_str("\n\n");
+            }
+        }
+        output.push_str(&sym.text);
+    }
 
     // Ensure trailing newline
     if !output.ends_with('\n') {

--- a/crates/dk-engine/src/parser/python_parser.rs
+++ b/crates/dk-engine/src/parser/python_parser.rs
@@ -98,13 +98,25 @@ impl PythonParser {
     /// Collect preceding `#` comments for a node.
     ///
     /// Preserves the `#` prefix so that AST merge can reconstruct valid Python.
+    /// Skips inline comments that belong to a preceding statement (e.g.
+    /// `x = 60  # 60 seconds` — the `# 60 seconds` is on the same line as
+    /// `x = 60` and should not be collected as a doc comment of the next symbol).
     fn doc_comments(node: &Node, source: &[u8]) -> Option<String> {
         let mut comments = Vec::new();
         let mut sibling = node.prev_sibling();
 
         while let Some(prev) = sibling {
             if prev.kind() == "comment" {
-                // Preserve the full comment text including `#` prefix
+                // Skip inline comments: if this comment is on the same line
+                // as a preceding non-comment sibling, it belongs to that
+                // sibling, not to our node.
+                if let Some(before_comment) = prev.prev_sibling() {
+                    if before_comment.kind() != "comment"
+                        && before_comment.end_position().row == prev.start_position().row
+                    {
+                        break;
+                    }
+                }
                 let text = Self::node_text(&prev, source).trim().to_string();
                 comments.push(text);
                 sibling = prev.prev_sibling();

--- a/crates/dk-engine/tests/ast_merge_test.rs
+++ b/crates/dk-engine/tests/ast_merge_test.rs
@@ -545,3 +545,130 @@ fn test_python_merge_preserves_import_order() {
         "import hashlib should come before import logging (base order preserved)"
     );
 }
+
+/// Reproduction test using the EXACT production auth.py structure:
+/// - Inline comments (`# 60 seconds` at end of assignment)
+/// - Multi-line comment blocks between variables
+/// - Module-level logger before functions
+/// - `from db import` mixed with stdlib imports
+#[test]
+fn test_python_merge_exact_production_file() {
+    let base = concat!(
+        "import datetime\n",
+        "import hashlib\n",
+        "import logging\n",
+        "import secrets\n",
+        "import time\n",
+        "from db import get_user_by_email\n",
+        "\n",
+        "logger = logging.getLogger(__name__)\n",
+        "\n",
+        "# Rate limiting: track all login attempts per email\n",
+        "# Each entry is a list of timestamps of attempts\n",
+        "_login_attempts: dict[str, list[float]] = {}\n",
+        "\n",
+        "# Global rate limit\n",
+        "_LOGIN_RATE_LIMIT_MAX = 5\n",
+        "_LOGIN_RATE_LIMIT_WINDOW = 60  # 60 seconds\n",
+        "\n",
+        "LOCKOUT_THRESHOLD = 3\n",
+        "\n",
+        "\n",
+        "def hash_password(password: str) -> str:\n",
+        "    return hashlib.sha256(password.encode()).hexdigest()\n",
+        "\n",
+        "\n",
+        "def verify_password(password: str, hashed: str) -> bool:\n",
+        "    return hash_password(password) == hashed\n",
+        "\n",
+        "\n",
+        "def generate_token(user_id: str) -> str:\n",
+        "    \"\"\"Generate an authentication token with expiry timestamp.\"\"\"\n",
+        "    expiry = datetime.datetime.utcnow() + datetime.timedelta(hours=24)\n",
+        "    return f\"{user_id}:{expiry.isoformat()}\"\n",
+        "\n",
+        "\n",
+        "def authenticate(email: str, password: str) -> dict | None:\n",
+        "    \"\"\"Authenticate a user by email and password.\"\"\"\n",
+        "    logger.info(f\"Authentication attempt for {email}\")\n",
+        "    return None\n",
+    );
+
+    // Alpha: add docstring to hash_password only
+    let version_a = base.replace(
+        "def hash_password(password: str) -> str:\n    return hashlib.sha256(password.encode()).hexdigest()",
+        "def hash_password(password: str) -> str:\n    \"\"\"Hash using SHA-256. [Alpha]\"\"\"\n    return hashlib.sha256(password.encode()).hexdigest()",
+    );
+
+    // Beta: modify generate_token docstring only
+    let version_b = base.replace(
+        "\"\"\"Generate an authentication token with expiry timestamp.\"\"\"",
+        "\"\"\"Generate a 24-hour token. [Beta]\"\"\"",
+    );
+
+    let result = ast_merge(&registry(), "auth.py", base, &version_a, &version_b)
+        .expect("ast_merge should succeed for production-like Python file");
+
+    // Print full output for debugging
+    eprintln!("=== MERGED OUTPUT ===\n{}\n=== END ===", result.merged_content);
+
+    assert_eq!(
+        result.status,
+        MergeStatus::Clean,
+        "Different functions should merge cleanly, got conflicts: {:?}",
+        result.conflicts
+    );
+
+    // Both changes preserved
+    assert!(
+        result.merged_content.contains("[Alpha]"),
+        "Alpha's docstring must be in output"
+    );
+    assert!(
+        result.merged_content.contains("[Beta]"),
+        "Beta's docstring must be in output"
+    );
+
+    // Comments must keep # prefix
+    assert!(
+        result.merged_content.contains("# Rate limiting"),
+        "Comment must retain # prefix. Output:\n{}",
+        result.merged_content
+    );
+    assert!(
+        result.merged_content.contains("# Global rate limit"),
+        "Comment must retain # prefix"
+    );
+
+    // logger must be before authenticate
+    let logger_pos = result.merged_content.find("logger = logging.getLogger");
+    let auth_pos = result.merged_content.find("def authenticate");
+    assert!(
+        logger_pos.unwrap() < auth_pos.unwrap(),
+        "logger must appear before authenticate. Output:\n{}",
+        result.merged_content
+    );
+
+    // Imports: stdlib before local
+    let hashlib_pos = result.merged_content.find("import hashlib").unwrap();
+    let from_db_pos = result.merged_content.find("from db import").unwrap();
+    assert!(
+        hashlib_pos < from_db_pos,
+        "stdlib imports must come before local imports. Output:\n{}",
+        result.merged_content
+    );
+
+    // Inline comments must stay on the same line as their assignment
+    assert!(
+        result.merged_content.contains("_LOGIN_RATE_LIMIT_WINDOW = 60  # 60 seconds"),
+        "Inline comment must stay on same line. Output:\n{}",
+        result.merged_content
+    );
+
+    // No extra blank lines between consecutive variable assignments
+    assert!(
+        !result.merged_content.contains("_LOGIN_RATE_LIMIT_MAX = 5\n\n_LOGIN_RATE_LIMIT_WINDOW"),
+        "Consecutive variables should not have blank line between them. Output:\n{}",
+        result.merged_content
+    );
+}


### PR DESCRIPTION
## Summary

Three remaining issues from v0.2.45 AST merge, found during production E2E QA:

### 1. Inline comments detached from their line
`_LOGIN_RATE_LIMIT_WINDOW = 60  # 60 seconds` became:
```
_LOGIN_RATE_LIMIT_WINDOW = 60

# 60 seconds
```
**Root cause:** tree-sitter's `expression_statement` span excludes trailing inline comments (they're sibling `comment` nodes).
**Fix:** In `extract_spans`, extend body extraction to include trailing content up to newline.

### 2. Inline comments stolen as doc_comments
`# 60 seconds` was collected by `doc_comments()` of `_failed_attempts` (the next symbol).
**Root cause:** `doc_comments()` walks backward through ALL comment siblings without checking if they're inline on a preceding statement's line.
**Fix:** Skip comments where `prev_sibling.end_position().row == comment.start_position().row`.

### 3. Double newlines between consecutive variables
`MAX = 5\n\nTIMEOUT = 60` — unwanted blank line between variables.
**Root cause:** `symbol_texts.join("\n\n")` uses double newline for ALL symbols uniformly.
**Fix:** Single newline between consecutive variables, double newline before/after functions/classes.

### Verified merged output (production-exact test)
```python
import datetime
import hashlib
...
from db import get_user_by_email

logger = logging.getLogger(__name__)
# Rate limiting: track all login attempts per email
# Each entry is a list of timestamps of attempts
_login_attempts: dict[str, list[float]] = {}
# Global rate limit
_LOGIN_RATE_LIMIT_MAX = 5
_LOGIN_RATE_LIMIT_WINDOW = 60  # 60 seconds
LOCKOUT_THRESHOLD = 3

def hash_password(password: str) -> str:
    """Hash using SHA-256. [Alpha]"""
    return hashlib.sha256(password.encode()).hexdigest()

def generate_token(user_id: str) -> str:
    """Generate a 24-hour token. [Beta]"""
    ...
```

## Test plan
- [x] All 18 merge tests pass (15 AST + 3 NSI)
- [x] Production-exact test: inline comment on same line, no extra blank lines, both changes preserved
- [ ] Deploy and re-run E2E QA multi-agent merge