### PR TITLE
fix(parser): Tier 1 review fixes — Go imports, Java calls, C++ docs

### DIFF
--- a/crates/dk-engine/src/parser/langs/cpp.rs
+++ b/crates/dk-engine/src/parser/langs/cpp.rs
@@ -13,6 +13,9 @@ impl LanguageConfig for CppConfig {
     }
 
     fn extensions(&self) -> &'static [&'static str] {
+        // .c and .h are parsed with the C++ grammar (a superset of C).
+        // K&R-style definitions and some C99/C11 constructs may not be
+        // captured perfectly, but coverage for modern C is acceptable.
         &["cpp", "cc", "cxx", "c", "h", "hpp", "hxx"]
     }
 

--- a/crates/dk-engine/src/parser/queries/go_imports.scm
+++ b/crates/dk-engine/src/parser/queries/go_imports.scm
@@ -6,27 +6,19 @@
 ;
 ; Go imports use the last segment of the path as the imported name by default.
 ; The engine's fallback logic (rsplit on '/') handles this automatically.
+;
+; Uses `(package_identifier)?` to match both aliased and non-aliased imports
+; in a single pattern, avoiding duplicate matches.
 
-; ── Single import: import "fmt" ──
+; ── Single import: import "fmt" or import alias "path/to/pkg" ──
 (import_declaration
   (import_spec
+    (package_identifier)? @alias
     path: (interpreted_string_literal) @module))
 
-; ── Aliased import: import alias "path/to/pkg" ──
-(import_declaration
-  (import_spec
-    name: (package_identifier) @alias
-    path: (interpreted_string_literal) @module))
-
-; ── Grouped imports: import ( "fmt" \n "net/http" ) ──
+; ── Grouped imports: import ( "fmt" \n alias "path/to/pkg" ) ──
 (import_declaration
   (import_spec_list
     (import_spec
-      path: (interpreted_string_literal) @module)))
-
-; ── Grouped aliased imports ──
-(import_declaration
-  (import_spec_list
-    (import_spec
-      name: (package_identifier) @alias
+      (package_identifier)? @alias
       path: (interpreted_string_literal) @module)))

--- a/crates/dk-engine/src/parser/queries/java_calls.scm
+++ b/crates/dk-engine/src/parser/queries/java_calls.scm
@@ -1,17 +1,20 @@
 ; Java call-site extraction queries for QueryDrivenParser.
 ;
 ; Captures:
-;   @callee        — the called method/function name
-;   @method_callee — the method name in a chained method invocation
+;   @callee        — the called method/function name (standalone calls)
+;   @method_callee — the method name in a receiver-qualified invocation
 ;   @call          — the entire call node (used for span)
 
-; Method invocations: obj.method() or method()
-; method_invocation has a `name` field for the method identifier and
-; an optional `object` field for the receiver.
-
-; Standalone method calls: method() or ClassName.method()
+; Standalone method calls (no receiver): method()
+; The `!object` predicate excludes method_invocations that have a receiver.
 (method_invocation
+  !object
   name: (identifier) @callee) @call
+
+; Receiver method calls: obj.method() or ClassName.method()
+(method_invocation
+  object: (_)
+  name: (identifier) @method_callee) @call
 
 ; Constructor calls: new Foo()
 (object_creation_expression


### PR DESCRIPTION
## Summary

- Fix duplicate Go import entries for aliased imports by merging patterns with `(package_identifier)?`
- Fix Java method call classification: receiver-qualified calls (`obj.method()`) now correctly emit `MethodCall` instead of `DirectCall` using `!object` / `object: _` field predicates
- Document C/H extension trade-off in CppConfig

## Test plan

- [ ] All 5 Go parser tests pass (import dedup verified)
- [ ] All 5 Java parser tests pass (call kinds verified)
- [ ] All 5 C++ parser tests pass
- [ ] All 15 AST merge tests pass
- [ ] `cargo clippy -- -D warnings` clean
- [ ] CI passes