### PR TITLE
ci: speed up CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
+  CARGO_INCREMENTAL: 0
 
 permissions:
   contents: write
@@ -23,6 +24,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Proto sync check
@@ -34,6 +37,7 @@ jobs:
 
   test:
     name: Test
+    needs: [check]
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -53,12 +57,18 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Configure git identity
         run: |
           git config --global user.email "ci@dkod.io"
           git config --global user.name "dkod-ci"
+      - name: Build tests
+        env:
+          DATABASE_URL: postgres://dekode:dekode@localhost:5432/dekode_test
+        run: cargo test --workspace --no-run
       - name: Run tests
         env:
           DATABASE_URL: postgres://dekode:dekode@localhost:5432/dekode_test


### PR DESCRIPTION
## Summary
- Run test job after check job (reuses compiled artifacts via shared rust-cache)
- Split `cargo test` into build + run steps for better progress visibility
- Add `cache-on-failure: true` to preserve cache even on test failures
- Add `CARGO_INCREMENTAL=0` for faster clean builds and smaller cache size

## Problem
The Test job takes 60-90 minutes, mostly compiling 15 tree-sitter C grammars from scratch. Check and Test run in parallel but compile the same code twice independently.

## Solution
By making Test depend on Check (`needs: [check]`), the rust-cache from Check is available when Test starts. Tree-sitter grammars and Rust compilation artifacts are cached, so Test only needs to compile the test harnesses.

## Expected improvement
- Check: ~5-8 min (same as before)
- Test: ~10-15 min (down from 60-90 min) — most artifacts cached from Check
- Total: ~15-20 min sequential (down from ~90 min parallel-but-slow)

## Test plan
- This PR is the test — compare CI timings against previous runs