### PR TITLE
fix: show git tag version in dk --version

### DIFF
--- a/crates/dk-cli/build.rs
+++ b/crates/dk-cli/build.rs
@@ -21,5 +21,22 @@ fn main() {
     }
 
     // Rerun when tags change.
-    println!("cargo:rerun-if-changed=.git/refs/tags");
+    // cargo:rerun-if-changed paths are relative to the package root (crates/dk-cli/),
+    // so we walk up from CARGO_MANIFEST_DIR to find the workspace root containing .git.
+    // We also watch packed-refs (where CI-fetched tags land) and HEAD.
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    if let Some(root) = manifest.ancestors().find(|p| p.join(".git").exists()) {
+        println!(
+            "cargo:rerun-if-changed={}",
+            root.join(".git/refs/tags").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            root.join(".git/packed-refs").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            root.join(".git/HEAD").display()
+        );
+    }
 }

--- a/crates/dk-cli/build.rs
+++ b/crates/dk-cli/build.rs
@@ -1,0 +1,25 @@
+use std::process::Command;
+
+fn main() {
+    // Get version from git tag (e.g. "v0.2.68" → "0.2.68").
+    // Falls back to Cargo.toml version if git is unavailable.
+    let version = Command::new("git")
+        .args(["describe", "--tags", "--abbrev=0"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                String::from_utf8(o.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|v| v.trim().trim_start_matches('v').to_string());
+
+    if let Some(ver) = version {
+        println!("cargo:rustc-env=DK_VERSION={ver}");
+    }
+
+    // Rerun when tags change.
+    println!("cargo:rerun-if-changed=.git/refs/tags");
+}

--- a/crates/dk-cli/src/main.rs
+++ b/crates/dk-cli/src/main.rs
@@ -17,7 +17,11 @@ use output::Output;
 const DEFAULT_SERVER: &str = "https://agent.dkod.io:443";
 
 #[derive(Parser)]
-#[command(name = "dk", about = "dkod CLI — agent-native code platform", version)]
+#[command(
+    name = "dk",
+    about = "dkod CLI — agent-native code platform",
+    version = option_env!("DK_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
## Summary
- `dk --version` showed `0.1.0` (hardcoded workspace Cargo.toml version) instead of the actual release tag (e.g. `v0.2.68`)
- Added `build.rs` that reads the latest git tag via `git describe --tags --abbrev=0` and injects it as `DK_VERSION`
- Falls back to `CARGO_PKG_VERSION` if git is unavailable (e.g. crates.io builds)

## Test plan
- [ ] `cargo run -p dk-cli -- --version` → `dk 0.2.68` (or current tag)
- [ ] Build without git (crates.io) → falls back to Cargo.toml version

🤖 Generated with [Claude Code](https://claude.com/claude-code)