### PR TITLE
feat: CLI improvements — git tag version + approve/review/status commands

### DIFF
--- a/crates/dk-cli/build.rs
+++ b/crates/dk-cli/build.rs
@@ -1,0 +1,42 @@
+use std::process::Command;
+
+fn main() {
+    // Get version from git tag (e.g. "v0.2.68" → "0.2.68").
+    // Falls back to Cargo.toml version if git is unavailable.
+    let version = Command::new("git")
+        .args(["describe", "--tags", "--abbrev=0"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                String::from_utf8(o.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|v| v.trim().trim_start_matches('v').to_string());
+
+    if let Some(ver) = version {
+        println!("cargo:rustc-env=DK_VERSION={ver}");
+    }
+
+    // Rerun when tags change.
+    // cargo:rerun-if-changed paths are relative to the package root (crates/dk-cli/),
+    // so we walk up from CARGO_MANIFEST_DIR to find the workspace root containing .git.
+    // We also watch packed-refs (where CI-fetched tags land) and HEAD.
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    if let Some(root) = manifest.ancestors().find(|p| p.join(".git").exists()) {
+        println!(
+            "cargo:rerun-if-changed={}",
+            root.join(".git/refs/tags").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            root.join(".git/packed-refs").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            root.join(".git/HEAD").display()
+        );
+    }
+}

--- a/crates/dk-cli/src/commands/agent.rs
+++ b/crates/dk-cli/src/commands/agent.rs
@@ -5,9 +5,10 @@ use clap::Subcommand;
 use colored::Colorize;
 use dk_protocol::agent_service_client::AgentServiceClient;
 use dk_protocol::{
-    merge_response, Change as ProtoChange, ChangeType, ContextDepth, ContextRequest,
-    FileListRequest, FileReadRequest, FileWriteRequest, MergeRequest, PreSubmitCheckRequest,
-    SubmitRequest, VerifyRequest, WatchRequest,
+    merge_response, ApproveRequest, Change as ProtoChange, ChangeType, ContextDepth,
+    ContextRequest, FileListRequest, FileReadRequest, FileWriteRequest, MergeRequest,
+    PreSubmitCheckRequest, ReviewRequest, SessionStatusRequest, SubmitRequest, VerifyRequest,
+    WatchRequest,
 };
 use tokio_stream::StreamExt;
 use tonic::transport::Channel;
@@ -162,6 +163,39 @@ pub enum AgentAction {
         #[arg(long, default_value = "http://[::1]:50051")]
         server: String,
     },
+
+    /// Approve a submitted changeset
+    Approve {
+        /// Session ID
+        #[arg(long)]
+        session: String,
+        /// gRPC server address
+        #[arg(long, default_value = "http://[::1]:50051")]
+        server: String,
+    },
+
+    /// Show code review findings for a changeset
+    Review {
+        /// Session ID
+        #[arg(long)]
+        session: String,
+        /// Changeset ID
+        #[arg(long)]
+        changeset: String,
+        /// gRPC server address
+        #[arg(long, default_value = "http://[::1]:50051")]
+        server: String,
+    },
+
+    /// Show session status and workspace info
+    Status {
+        /// Session ID
+        #[arg(long)]
+        session: String,
+        /// gRPC server address
+        #[arg(long, default_value = "http://[::1]:50051")]
+        server: String,
+    },
 }
 
 pub fn run(action: AgentAction) -> Result<()> {
@@ -231,6 +265,16 @@ async fn run_async(action: AgentAction) -> Result<()> {
         } => file_list_cmd(server, session, prefix, only_modified).await,
 
         AgentAction::PreSubmit { session, server } => pre_submit_cmd(server, session).await,
+
+        AgentAction::Approve { session, server } => approve_cmd(server, session).await,
+
+        AgentAction::Review {
+            session,
+            changeset,
+            server,
+        } => review_cmd(server, session, changeset).await,
+
+        AgentAction::Status { session, server } => status_cmd(server, session).await,
     }
 }
 
@@ -718,6 +762,146 @@ async fn pre_submit_cmd(server: String, session: String) -> Result<()> {
         "\nSummary: {} file(s) modified, {} symbol(s) changed",
         resp.files_modified, resp.symbols_changed,
     );
+
+    Ok(())
+}
+
+// ── APPROVE ─────────────────────────────────────────────────────────────────
+
+async fn approve_cmd(server: String, session: String) -> Result<()> {
+    let mut client = grpc_client(&server).await?;
+
+    let resp = client
+        .approve(ApproveRequest {
+            session_id: session,
+        })
+        .await?
+        .into_inner();
+
+    if resp.success {
+        println!(
+            "{} changeset={}  state={}",
+            "Approved.".green().bold(),
+            resp.changeset_id,
+            resp.new_state,
+        );
+    } else {
+        println!(
+            "{} {}",
+            "Approve failed.".red().bold(),
+            resp.message,
+        );
+    }
+    if resp.success && !resp.message.is_empty() {
+        println!("  {}", resp.message);
+    }
+
+    Ok(())
+}
+
+// ── REVIEW ──────────────────────────────────────────────────────────────────
+
+async fn review_cmd(server: String, session: String, changeset: String) -> Result<()> {
+    let mut client = grpc_client(&server).await?;
+
+    let resp = client
+        .review(ReviewRequest {
+            session_id: session,
+            changeset_id: changeset,
+        })
+        .await?
+        .into_inner();
+
+    if resp.reviews.is_empty() {
+        println!("No reviews found for this changeset.");
+        return Ok(());
+    }
+
+    for review in &resp.reviews {
+        let score = review
+            .score
+            .map(|s| format!("{}/5", s))
+            .unwrap_or_else(|| "N/A".to_string());
+        let summary = review
+            .summary
+            .as_deref()
+            .unwrap_or("No summary");
+        let tier_display = match review.tier.as_str() {
+            "local" => "local".cyan().to_string(),
+            "deep" => "deep".magenta().to_string(),
+            other => other.to_string(),
+        };
+
+        println!(
+            "\n{} {} review — score {} — {} finding(s)",
+            "▸".bold(),
+            tier_display,
+            score.bold(),
+            review.findings.len(),
+        );
+        println!("  {}", summary);
+
+        for finding in &review.findings {
+            let severity_display = match finding.severity.as_str() {
+                "error" => "ERROR".red().bold().to_string(),
+                "warning" => "WARN".yellow().bold().to_string(),
+                "info" => "INFO".cyan().to_string(),
+                other => other.to_string(),
+            };
+            let location = match (finding.line_start, finding.line_end) {
+                (Some(start), Some(end)) if start != end => {
+                    format!("{}:{}-{}", finding.file_path, start, end)
+                }
+                (Some(start), _) => format!("{}:{}", finding.file_path, start),
+                _ => finding.file_path.clone(),
+            };
+            let dismissed = if finding.dismissed { " [dismissed]" } else { "" };
+            println!(
+                "  {} {} {}{}",
+                severity_display, location, finding.message, dismissed,
+            );
+            if let Some(ref suggestion) = finding.suggestion {
+                println!("    {} {}", "fix:".green(), suggestion);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ── STATUS ──────────────────────────────────────────────────────────────────
+
+async fn status_cmd(server: String, session: String) -> Result<()> {
+    let mut client = grpc_client(&server).await?;
+
+    let resp = client
+        .get_session_status(SessionStatusRequest {
+            session_id: session.clone(),
+        })
+        .await?
+        .into_inner();
+
+    println!("{}", "Session Status".green().bold());
+    println!("  Session:           {}", resp.session_id);
+    println!("  Base commit:       {}", resp.base_commit);
+    println!("  Files modified:    {}", resp.files_modified.len());
+    println!("  Symbols modified:  {}", resp.symbols_modified.len());
+    println!("  Overlay size:      {} bytes", resp.overlay_size_bytes);
+    println!("  Other sessions:    {}", resp.active_other_sessions);
+
+    if !resp.files_modified.is_empty() {
+        println!("\n  Modified files:");
+        for f in &resp.files_modified {
+            println!("    {} {}", "M".yellow(), f);
+        }
+    }
+
+    if !resp.symbols_modified.is_empty() {
+        println!("\n  Modified symbols:");
+        for s in &resp.symbols_modified {
+            println!("    {} {}", "∆".cyan(), s);
+        }
+    }
 
     Ok(())
 }

--- a/crates/dk-cli/src/main.rs
+++ b/crates/dk-cli/src/main.rs
@@ -17,7 +17,11 @@ use output::Output;
 const DEFAULT_SERVER: &str = "https://agent.dkod.io:443";
 
 #[derive(Parser)]
-#[command(name = "dk", about = "dkod CLI — agent-native code platform", version)]
+#[command(
+    name = "dk",
+    about = "dkod CLI — agent-native code platform",
+    version = option_env!("DK_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
## Summary
Single squashed commit combining PRs #53 and #54:

**Version fix:**
- `dk --version` now shows the git tag (e.g. `0.2.68`) instead of hardcoded `0.1.0`
- `build.rs` reads the latest tag via `git describe --tags`; falls back to `CARGO_PKG_VERSION`

**Missing CLI commands:**
| MCP tool | CLI command | Description |
|----------|-------------|-------------|
| `dk_approve` | `dk agent approve` | Approve a submitted changeset |
| `dk_review` | `dk agent review` | Show code review findings (local + deep) |
| `dk_status` | `dk agent status` | Show session status and workspace info |

Replaces #53 and #54.

## Test plan
- [ ] `dk --version` → shows git tag version
- [ ] `dk agent approve --session <sid>` — approves changeset
- [ ] `dk agent review --session <sid> --changeset <cid>` — shows findings
- [ ] `dk agent status --session <sid>` — shows session info
- [ ] `dk agent --help` — all commands listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)