### PR TITLE
fix: pass DK_VERSION from CI to build.rs for correct dk --version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,11 @@ jobs:
         run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Build binaries
+        env:
+          DK_VERSION: ${{ needs.version.outputs.version }}
         run: |
+          # Strip leading 'v' for the version shown by dk --version
+          export DK_VERSION="${DK_VERSION#v}"
           if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
             cross build --release --target ${{ matrix.target }} -p dk-cli -p dk-server -p dk-mcp
           else

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,6 @@
+[build.env]
+passthrough = ["DK_VERSION"]
+
 [target.aarch64-unknown-linux-gnu]
 pre-build = [
     "dpkg --add-architecture $CROSS_DEB_ARCH",

--- a/crates/dk-cli/build.rs
+++ b/crates/dk-cli/build.rs
@@ -1,24 +1,27 @@
 use std::process::Command;
 
 fn main() {
-    // Get version from git tag (e.g. "v0.2.68" → "0.2.68").
-    // Falls back to Cargo.toml version if git is unavailable.
-    let version = Command::new("git")
-        .args(["describe", "--tags", "--abbrev=0"])
-        .output()
-        .ok()
-        .and_then(|o| {
-            if o.status.success() {
-                String::from_utf8(o.stdout).ok()
-            } else {
-                None
-            }
-        })
-        .map(|v| v.trim().trim_start_matches('v').to_string());
+    // Priority: DK_VERSION env var (set by CI) → git tag → Cargo.toml fallback.
+    // CI shallow clones don't have tags, so the version job passes it explicitly.
+    let version = std::env::var("DK_VERSION").ok().or_else(|| {
+        Command::new("git")
+            .args(["describe", "--tags", "--abbrev=0"])
+            .output()
+            .ok()
+            .and_then(|o| {
+                if o.status.success() {
+                    String::from_utf8(o.stdout).ok()
+                } else {
+                    None
+                }
+            })
+            .map(|v| v.trim().trim_start_matches('v').to_string())
+    });
 
     if let Some(ver) = version {
         println!("cargo:rustc-env=DK_VERSION={ver}");
     }
+    println!("cargo:rerun-if-env-changed=DK_VERSION");
 
     // Rerun when tags change.
     // cargo:rerun-if-changed paths are relative to the package root (crates/dk-cli/),


### PR DESCRIPTION
## Summary
- `dk --version` showed `0.1.0` in CI-built releases because `actions/checkout` does a shallow clone without tags
- `build.rs` now checks `DK_VERSION` env var first (set by CI), then falls back to `git describe`
- CI build step passes the computed version via `env: DK_VERSION`

## Test plan
- [ ] After merge, the next release binary should show the correct version (e.g. `dk 0.2.70`)
- [ ] Local builds still work (git tag fallback)
- [ ] `crates.io` builds work (CARGO_PKG_VERSION fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)