### PR TITLE
fix: session isolation + greenfield signal for parallel agents

### DIFF
--- a/crates/dk-mcp/src/server.rs
+++ b/crates/dk-mcp/src/server.rs
@@ -1158,14 +1158,17 @@ impl DkodMcp {
         }
 
         // Format output.
-        let summary_text = match &response.summary {
+        let codebase_line = match &response.summary {
+            Some(s) if s.total_files == 0 => {
+                "Codebase: 0 files (greenfield — no existing code to read)".to_string()
+            }
             Some(s) => format!(
-                "languages: {}\ntotal_symbols: {}\ntotal_files: {}",
-                s.languages.join(", "),
-                s.total_symbols,
+                "Codebase: {} files, {} symbols, {}",
                 s.total_files,
+                s.total_symbols,
+                s.languages.join(", "),
             ),
-            None => "no codebase summary available".to_string(),
+            None => "Codebase: summary unavailable".to_string(),
         };
 
         let text = format!(
@@ -1174,14 +1177,11 @@ impl DkodMcp {
              workspace_id: {}\n\
              changeset_id: {}\n\
              version:      {}\n\n\
-             IMPORTANT: Use this session_id ({}) in all subsequent dk_* tool calls \
-             when multiple sessions are active.\n\n\
-             Codebase summary:\n{summary_text}",
+             {codebase_line}",
             response.session_id,
             response.workspace_id,
             response.changeset_id,
             response.codebase_version,
-            response.session_id,
         );
 
         let has_nats_url = std::env::var("NATS_URL")

--- a/crates/dk-mcp/src/server.rs
+++ b/crates/dk-mcp/src/server.rs
@@ -287,11 +287,7 @@ impl DkodMcp {
     #[allow(clippy::new_without_default)]
     pub async fn new() -> Self {
         let state = SessionState::resolve().await;
-        let restored_sessions = crate::state::load_sessions();
-        let session_count = restored_sessions.len();
-        if session_count > 0 {
-            tracing::info!(count = session_count, "restored sessions from disk");
-        }
+        let restored_sessions = HashMap::new();
         Self {
             tool_router: Self::tool_router(),
             connection: Arc::new(RwLock::new(state)),
@@ -413,8 +409,9 @@ impl DkodMcp {
 
     /// Get a clone of the cached gRPC client, or return an error if not connected.
     ///
-    /// If sessions were restored from disk but the gRPC client was lost (process
-    /// restart), this will lazily reconnect using the stored connection state.
+    /// If sessions exist in memory but the gRPC client was cleared (e.g. after
+    /// dk_merge closes the last session then a new dk_connect arrives), this
+    /// will lazily reconnect using the stored connection state.
     async fn get_client(&self) -> Result<AuthenticatedClient, McpError> {
         // Read sessions BEFORE acquiring grpc_client to maintain lock ordering:
         // sessions -> grpc_client (same order as dk_merge cleanup).
@@ -431,7 +428,7 @@ impl DkodMcp {
             return Ok(client.clone());
         }
 
-        // Slow path: sessions restored from disk but client not yet created.
+        // Slow path: sessions exist but gRPC client was cleared.
         // Reconnect using the stored connection state.
         if has_sessions {
             let (addr, env_token) = {
@@ -1020,12 +1017,10 @@ impl DkodMcp {
             changeset_id: response.changeset_id.clone(),
             repo_name: repo.clone(),
         };
-        let snapshot = {
+        {
             let mut sessions = self.sessions.write().await;
             sessions.insert(response.session_id.clone(), session_data);
-            sessions.clone()
-        };
-        crate::state::save_sessions(&snapshot);
+        }
 
         // Subscribe to NATS conflict events for this session (optional — skipped if
         // NATS_URL or NATS_OWNER_ID are not set, e.g. in local dev without NATS).
@@ -2139,16 +2134,14 @@ impl DkodMcp {
                 // prevent a TOCTOU race where a concurrent dk_connect inserts a new
                 // session between remove() and is_empty(), causing the client to be
                 // cleared while the new session still needs it.
-                let snapshot = {
+                {
                     let mut sessions = self.sessions.write().await;
                     sessions.remove(&session_id);
                     if sessions.is_empty() {
                         let mut cached = self.grpc_client.lock().await;
                         *cached = None;
                     }
-                    sessions.clone()
-                };
-                crate::state::save_sessions(&snapshot);
+                }
                 // Cancel and remove the per-session NATS task.
                 {
                     let mut cancellations = self.nats_cancellations.lock().await;
@@ -2195,16 +2188,14 @@ impl DkodMcp {
                     .drain_notifications(&session_id)
                     .await
                     .unwrap_or_default();
-                let snapshot = {
+                {
                     let mut sessions = self.sessions.write().await;
                     sessions.remove(&session_id);
                     if sessions.is_empty() {
                         let mut cached = self.grpc_client.lock().await;
                         *cached = None;
                     }
-                    sessions.clone()
-                };
-                crate::state::save_sessions(&snapshot);
+                }
                 {
                     let mut cancellations = self.nats_cancellations.lock().await;
                     if let Some(flag) = cancellations.remove(&session_id) {
@@ -2490,16 +2481,14 @@ impl DkodMcp {
 
         // Only clean up local session state when the server confirms the close.
         if response.success {
-            let snapshot = {
+            {
                 let mut sessions = self.sessions.write().await;
                 sessions.remove(&session_id);
                 if sessions.is_empty() {
                     let mut cached = self.grpc_client.lock().await;
                     *cached = None;
                 }
-                sessions.clone()
-            };
-            crate::state::save_sessions(&snapshot);
+            }
 
             // Cancel NATS task for this session.
             {

--- a/crates/dk-mcp/src/state.rs
+++ b/crates/dk-mcp/src/state.rs
@@ -2,44 +2,6 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-// ── Session persistence ───────────────────────────────────────────
-
-/// Path to the session cache file.
-fn sessions_file() -> PathBuf {
-    let dir = dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".dkod");
-    let _ = std::fs::create_dir_all(&dir);
-    dir.join("sessions.json")
-}
-
-/// Save sessions to disk. Best-effort — errors are logged but don't propagate.
-///
-/// Uses atomic write (write to tmp file, then rename) to prevent corruption
-/// if the process is killed mid-write. `rename` is atomic on POSIX when src
-/// and dst are on the same filesystem, which is always the case here.
-pub fn save_sessions(sessions: &HashMap<String, SessionData>) {
-    let path = sessions_file();
-    match serde_json::to_string(sessions) {
-        Ok(json) => {
-            let tmp = path.with_extension("json.tmp");
-            if let Err(e) = std::fs::write(&tmp, &json).and_then(|_| std::fs::rename(&tmp, &path)) {
-                tracing::warn!(path = %path.display(), error = %e, "failed to save sessions");
-            }
-        }
-        Err(e) => tracing::warn!(error = %e, "failed to serialize sessions"),
-    }
-}
-
-/// Load sessions from disk. Returns empty map on any error.
-pub fn load_sessions() -> HashMap<String, SessionData> {
-    let path = sessions_file();
-    match std::fs::read_to_string(&path) {
-        Ok(json) => serde_json::from_str(&json).unwrap_or_default(),
-        Err(_) => HashMap::new(),
-    }
-}
-
 /// Walk up from `start` looking for the workspace root (a `Cargo.toml` containing `[workspace]`).
 /// Falls back to the first `Cargo.toml` found if none contain `[workspace]`.
 pub fn find_repo_root(start: &Path) -> Option<PathBuf> {


### PR DESCRIPTION
## Summary

- **Remove session persistence from dk-mcp startup** — each dk-mcp process now starts with an empty session map instead of loading `~/.dkod/sessions.json`. This prevents parallel sub-agents from inheriting stale sessions from other dk-mcp instances, which caused "Multiple sessions active" errors during harness parallel builds.

- **Add greenfield signal to dk_connect output** — `dk_connect` now shows `Codebase: 0 files (greenfield — no existing code to read)` for empty repos, guiding agents to skip `dk_file_read` and `dk_context` calls. For existing repos, shows compact file/symbol/language counts.

Net change: **-49 lines** (22 added, 71 removed).

## Root cause

When the harness spawns parallel generators as Claude Code sub-agents, each gets its own dk-mcp process. On startup, every dk-mcp loaded `~/.dkod/sessions.json` — a shared file. Race condition:

1. Generator-1's dk-mcp starts, loads empty file, connects, saves session-1
2. Generator-2's dk-mcp starts, loads file — picks up session-1
3. Generator-2 connects — now has 2 sessions in its map
4. Generator-2 calls dk_file_write without session_id → "Multiple sessions active"

## What does NOT change

- Tool schemas — all `session_id: Option<String>` stays optional
- `resolve_session()` auto-resolve logic — still works when 1 session exists
- dk-cli — uses separate `~/.config/dkod/session.json`, completely unaffected
- Single-user MCP workflow — unchanged

## Test plan

- [x] `cargo check -p dk-mcp` — compiles clean
- [x] `cargo test -p dk-mcp` — all 23 tests pass
- [x] `cargo build -p dk-mcp --release` — release build succeeds
- [ ] Manual test: run harness parallel build with new binary, verify no "Multiple sessions active" errors