### PR TITLE
feat: symbol-level locking for concurrent agent coordination

### DIFF
--- a/crates/dk-engine/src/conflict/claim_tracker.rs
+++ b/crates/dk-engine/src/conflict/claim_tracker.rs
@@ -435,4 +435,192 @@ mod tests {
         assert!(names.contains(&"fn_a"));
         assert!(names.contains(&"fn_b"));
     }
+
+    // ── acquire_lock tests ──
+
+    #[test]
+    fn acquire_lock_unclaimed_succeeds() {
+        let tracker = SymbolClaimTracker::new();
+        let repo = Uuid::new_v4();
+        let session = Uuid::new_v4();
+
+        let result = tracker.acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn acquire_lock_same_session_succeeds() {
+        let tracker = SymbolClaimTracker::new();
+        let repo = Uuid::new_v4();
+        let session = Uuid::new_v4();
+
+        tracker.acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
+        ).unwrap();
+
+        // Same session re-acquiring same symbol should succeed
+        let result = tracker.acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn acquire_lock_cross_session_blocked() {
+        let tracker = SymbolClaimTracker::new();
+        let repo = Uuid::new_v4();
+        let session_a = Uuid::new_v4();
+        let session_b = Uuid::new_v4();
+
+        tracker.acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+        ).unwrap();
+
+        let result = tracker.acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session_b, "agent-2", "fn_a", SymbolKind::Function),
+        );
+        assert!(result.is_err());
+        let locked = result.unwrap_err();
+        assert_eq!(locked.qualified_name, "fn_a");
+        assert_eq!(locked.locked_by_session, session_a);
+        assert_eq!(locked.locked_by_agent, "agent-1");
+    }
+
+    #[test]
+    fn acquire_lock_different_symbols_same_file() {
+        let tracker = SymbolClaimTracker::new();
+        let repo = Uuid::new_v4();
+        let session_a = Uuid::new_v4();
+        let session_b = Uuid::new_v4();
+
+        tracker.acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+        ).unwrap();
+
+        // Different symbol in same file — should succeed
+        let result = tracker.acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session_b, "agent-2", "fn_b", SymbolKind::Function),
+        );
+        assert!(result.is_ok());
+    }
+
+    // ── release_lock tests ──
+
+    #[test]
+    fn release_lock_single_symbol() {
+        let tracker = SymbolClaimTracker::new();
+        let repo = Uuid::new_v4();
+        let session_a = Uuid::new_v4();
+        let session_b = Uuid::new_v4();
+
+        tracker.acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+        ).unwrap();
+
+        // Release the lock
+        tracker.release_lock(repo, "src/lib.rs", session_a, "fn_a");
+
+        // Now another session should be able to acquire it
+        let result = tracker.acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session_b, "agent-2", "fn_a", SymbolKind::Function),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn release_lock_cleans_empty_entries() {
+        let tracker = SymbolClaimTracker::new();
+        let repo = Uuid::new_v4();
+        let session = Uuid::new_v4();
+
+        tracker.acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
+        ).unwrap();
+
+        tracker.release_lock(repo, "src/lib.rs", session, "fn_a");
+
+        // The key should be removed from the map (no empty vecs lingering)
+        let key = (repo, "src/lib.rs".to_string());
+        assert!(tracker.claims.get(&key).is_none());
+    }
+
+    // ── release_locks tests ──
+
+    #[test]
+    fn release_locks_returns_released_entries() {
+        let tracker = SymbolClaimTracker::new();
+        let repo = Uuid::new_v4();
+        let session = Uuid::new_v4();
+
+        tracker.acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
+        ).unwrap();
+        tracker.acquire_lock(
+            repo,
+            "src/api.rs",
+            make_claim(session, "agent-1", "handler", SymbolKind::Function),
+        ).unwrap();
+
+        let released = tracker.release_locks(repo, session);
+        assert_eq!(released.len(), 2);
+
+        let names: Vec<&str> = released.iter().map(|r| r.qualified_name.as_str()).collect();
+        assert!(names.contains(&"fn_a"));
+        assert!(names.contains(&"handler"));
+    }
+
+    #[test]
+    fn release_locks_unblocks_other_session() {
+        let tracker = SymbolClaimTracker::new();
+        let repo = Uuid::new_v4();
+        let session_a = Uuid::new_v4();
+        let session_b = Uuid::new_v4();
+
+        tracker.acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+        ).unwrap();
+
+        // session_b is blocked
+        assert!(tracker.acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session_b, "agent-2", "fn_a", SymbolKind::Function),
+        ).is_err());
+
+        // Release session_a
+        tracker.release_locks(repo, session_a);
+
+        // session_b can now acquire
+        assert!(tracker.acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session_b, "agent-2", "fn_a", SymbolKind::Function),
+        ).is_ok());
+    }
 }

--- a/crates/dk-engine/src/conflict/claim_tracker.rs
+++ b/crates/dk-engine/src/conflict/claim_tracker.rs
@@ -131,6 +131,23 @@ impl SymbolClaimTracker {
         Ok(())
     }
 
+    /// Release a single symbol lock for a session in a specific file.
+    /// Used to roll back partially-acquired locks when a batch fails.
+    pub fn release_lock(
+        &self,
+        repo_id: Uuid,
+        file_path: &str,
+        session_id: Uuid,
+        qualified_name: &str,
+    ) {
+        let key = (repo_id, file_path.to_string());
+        if let Some(mut entry) = self.claims.get_mut(&key) {
+            entry.value_mut().retain(|c| {
+                !(c.session_id == session_id && c.qualified_name == qualified_name)
+            });
+        }
+    }
+
     /// Release all locks held by a session and return what was released.
     /// Callers should emit `symbol.lock.released` events for each returned entry.
     pub fn release_locks(&self, repo_id: Uuid, session_id: Uuid) -> Vec<ReleasedLock> {

--- a/crates/dk-engine/src/conflict/claim_tracker.rs
+++ b/crates/dk-engine/src/conflict/claim_tracker.rs
@@ -25,6 +25,28 @@ pub struct ConflictInfo {
     pub first_touched_at: Instant,
 }
 
+/// Information about a symbol lock held by another session.
+/// Returned when `acquire_lock` finds the symbol is already locked.
+#[derive(Debug, Clone)]
+pub struct SymbolLocked {
+    pub qualified_name: String,
+    pub kind: SymbolKind,
+    pub locked_by_session: Uuid,
+    pub locked_by_agent: String,
+    pub locked_since: Instant,
+    pub file_path: String,
+}
+
+/// Result of releasing locks for a session. Contains the symbols that
+/// were released, so callers can emit `symbol.lock.released` events.
+#[derive(Debug, Clone)]
+pub struct ReleasedLock {
+    pub file_path: String,
+    pub qualified_name: String,
+    pub kind: SymbolKind,
+    pub agent_name: String,
+}
+
 /// Thread-safe, lock-free tracker for symbol-level claims across sessions.
 ///
 /// Key insight: two sessions modifying DIFFERENT symbols in the same file is
@@ -65,6 +87,85 @@ impl SymbolClaimTracker {
         } else {
             claims.push(claim);
         }
+    }
+
+    /// Attempt to acquire a symbol lock. If the symbol is already claimed by
+    /// another session, returns `Err(SymbolLocked)` — the write MUST NOT proceed.
+    /// If claimed by the same session, or unclaimed, acquires and returns `Ok(())`.
+    ///
+    /// This is the blocking counterpart to `record_claim`. Use this when writes
+    /// should be rejected if another agent holds the symbol.
+    pub fn acquire_lock(
+        &self,
+        repo_id: Uuid,
+        file_path: &str,
+        claim: SymbolClaim,
+    ) -> Result<(), SymbolLocked> {
+        let key = (repo_id, file_path.to_string());
+        let mut entry = self.claims.entry(key).or_default();
+        let claims = entry.value_mut();
+
+        // Check if another session already holds this symbol
+        if let Some(existing) = claims.iter().find(|c| {
+            c.qualified_name == claim.qualified_name && c.session_id != claim.session_id
+        }) {
+            return Err(SymbolLocked {
+                qualified_name: claim.qualified_name,
+                kind: existing.kind.clone(),
+                locked_by_session: existing.session_id,
+                locked_by_agent: existing.agent_name.clone(),
+                locked_since: existing.first_touched_at,
+                file_path: file_path.to_string(),
+            });
+        }
+
+        // Same session re-acquisition or fresh claim — proceed
+        if let Some(existing) = claims.iter_mut().find(|c| {
+            c.session_id == claim.session_id && c.qualified_name == claim.qualified_name
+        }) {
+            existing.kind = claim.kind;
+            existing.agent_name = claim.agent_name;
+        } else {
+            claims.push(claim);
+        }
+        Ok(())
+    }
+
+    /// Release all locks held by a session and return what was released.
+    /// Callers should emit `symbol.lock.released` events for each returned entry.
+    pub fn release_locks(&self, repo_id: Uuid, session_id: Uuid) -> Vec<ReleasedLock> {
+        let mut released = Vec::new();
+        let mut empty_keys = Vec::new();
+
+        for mut entry in self.claims.iter_mut() {
+            let key = entry.key().clone();
+            if key.0 != repo_id {
+                continue;
+            }
+            let file_path = &key.1;
+            let claims = entry.value_mut();
+
+            // Collect released locks before removing
+            for claim in claims.iter().filter(|c| c.session_id == session_id) {
+                released.push(ReleasedLock {
+                    file_path: file_path.clone(),
+                    qualified_name: claim.qualified_name.clone(),
+                    kind: claim.kind.clone(),
+                    agent_name: claim.agent_name.clone(),
+                });
+            }
+
+            claims.retain(|c| c.session_id != session_id);
+            if claims.is_empty() {
+                empty_keys.push(key);
+            }
+        }
+
+        for key in empty_keys {
+            self.claims.remove_if(&key, |_, v| v.is_empty());
+        }
+
+        released
     }
 
     /// Check whether any of the given `qualified_names` are already claimed by

--- a/crates/dk-engine/src/conflict/claim_tracker.rs
+++ b/crates/dk-engine/src/conflict/claim_tracker.rs
@@ -37,6 +37,15 @@ pub struct SymbolLocked {
     pub file_path: String,
 }
 
+/// Outcome of a successful `acquire_lock` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AcquireOutcome {
+    /// Lock freshly acquired — include in rollback list.
+    Fresh,
+    /// Session already held this lock — exclude from rollback.
+    ReAcquired,
+}
+
 /// Result of releasing locks for a session. Contains the symbols that
 /// were released, so callers can emit `symbol.lock.released` events.
 #[derive(Debug, Clone)]
@@ -100,7 +109,7 @@ impl SymbolClaimTracker {
         repo_id: Uuid,
         file_path: &str,
         claim: SymbolClaim,
-    ) -> Result<(), SymbolLocked> {
+    ) -> Result<AcquireOutcome, SymbolLocked> {
         let key = (repo_id, file_path.to_string());
         let mut entry = self.claims.entry(key).or_default();
         let claims = entry.value_mut();
@@ -119,16 +128,18 @@ impl SymbolClaimTracker {
             });
         }
 
-        // Same session re-acquisition or fresh claim — proceed
+        // Same session re-acquisition — update metadata, return ReAcquired
         if let Some(existing) = claims.iter_mut().find(|c| {
             c.session_id == claim.session_id && c.qualified_name == claim.qualified_name
         }) {
             existing.kind = claim.kind;
             existing.agent_name = claim.agent_name;
-        } else {
-            claims.push(claim);
+            return Ok(AcquireOutcome::ReAcquired);
         }
-        Ok(())
+
+        // Fresh claim
+        claims.push(claim);
+        Ok(AcquireOutcome::Fresh)
     }
 
     /// Release a single symbol lock for a session in a specific file.

--- a/crates/dk-engine/src/conflict/claim_tracker.rs
+++ b/crates/dk-engine/src/conflict/claim_tracker.rs
@@ -146,6 +146,8 @@ impl SymbolClaimTracker {
                 !(c.session_id == session_id && c.qualified_name == qualified_name)
             });
         }
+        // Clean up empty entries to prevent unbounded growth from repeated rollbacks
+        self.claims.remove_if(&key, |_, v| v.is_empty());
     }
 
     /// Release all locks held by a session and return what was released.

--- a/crates/dk-engine/src/conflict/claim_tracker.rs
+++ b/crates/dk-engine/src/conflict/claim_tracker.rs
@@ -269,21 +269,35 @@ impl SymbolClaimTracker {
         results
     }
 
-    /// Remove all claims belonging to a session (e.g. on disconnect or GC).
-    pub fn clear_session(&self, session_id: Uuid) {
-        // Iterate all entries and remove claims for the given session.
-        // Empty entries are cleaned up to avoid unbounded memory growth.
+    /// Remove all claims belonging to a session across ALL repos (e.g. on
+    /// disconnect or GC). Returns the released locks so callers can emit
+    /// `symbol.lock.released` events to unblock waiting agents.
+    pub fn clear_session(&self, session_id: Uuid) -> Vec<ReleasedLock> {
+        let mut released = Vec::new();
         let mut empty_keys = Vec::new();
         for mut entry in self.claims.iter_mut() {
-            entry.value_mut().retain(|c| c.session_id != session_id);
-            if entry.value().is_empty() {
-                empty_keys.push(entry.key().clone());
+            let key = entry.key().clone();
+            let file_path = &key.1;
+            let claims = entry.value_mut();
+
+            for claim in claims.iter().filter(|c| c.session_id == session_id) {
+                released.push(ReleasedLock {
+                    file_path: file_path.clone(),
+                    qualified_name: claim.qualified_name.clone(),
+                    kind: claim.kind.clone(),
+                    agent_name: claim.agent_name.clone(),
+                });
+            }
+
+            claims.retain(|c| c.session_id != session_id);
+            if claims.is_empty() {
+                empty_keys.push(key);
             }
         }
         for key in empty_keys {
-            // Re-check under write lock to avoid race
             self.claims.remove_if(&key, |_, v| v.is_empty());
         }
+        released
     }
 }
 

--- a/crates/dk-engine/src/conflict/mod.rs
+++ b/crates/dk-engine/src/conflict/mod.rs
@@ -3,7 +3,7 @@ mod claim_tracker;
 pub mod payload;
 
 pub use ast_merge::{ast_merge, MergeResult, MergeStatus, SymbolConflict};
-pub use claim_tracker::{ConflictInfo, ReleasedLock, SymbolClaim, SymbolClaimTracker, SymbolLocked};
+pub use claim_tracker::{AcquireOutcome, ConflictInfo, ReleasedLock, SymbolClaim, SymbolClaimTracker, SymbolLocked};
 pub use payload::{
     build_conflict_block, build_conflict_detail, ConflictBlock, SymbolConflictDetail,
     SymbolVersion,

--- a/crates/dk-engine/src/conflict/mod.rs
+++ b/crates/dk-engine/src/conflict/mod.rs
@@ -3,7 +3,7 @@ mod claim_tracker;
 pub mod payload;
 
 pub use ast_merge::{ast_merge, MergeResult, MergeStatus, SymbolConflict};
-pub use claim_tracker::{ConflictInfo, SymbolClaim, SymbolClaimTracker};
+pub use claim_tracker::{ConflictInfo, ReleasedLock, SymbolClaim, SymbolClaimTracker, SymbolLocked};
 pub use payload::{
     build_conflict_block, build_conflict_detail, ConflictBlock, SymbolConflictDetail,
     SymbolVersion,

--- a/crates/dk-protocol/src/file_write.rs
+++ b/crates/dk-protocol/src/file_write.rs
@@ -76,82 +76,59 @@ pub async fn handle_file_write(
     // Drop workspace guard before further work
     drop(ws);
 
-    // Also record in changeset_files so the verify pipeline can materialize them.
     let op = if is_new { "add" } else { "modify" };
-    let content_str = std::str::from_utf8(&req.content).ok();
-    let _ = engine
-        .changeset_store()
-        .upsert_file(changeset_id, &req.path, op, content_str)
-        .await;
 
     // Detect symbol changes by diffing old vs new file content.
     // Only symbols whose source text actually changed are reported.
     let (detected_changes, all_symbol_changes) =
         detect_symbol_changes_diffed(engine, &req.path, &old_content, &req.content, is_new);
 
-    // ── Symbol locking ──
-    // Attempt to acquire locks for each "added" or "modified" symbol. If another
-    // session holds the lock on any symbol, the write is REJECTED — the overlay
-    // write already happened but we revert it by re-writing the old content (or
-    // removing the file if it was new). The agent must dk_watch for lock release,
-    // then dk_file_read and retry.
+    // ── Symbol locking (check-then-acquire) ──
+    // First check ALL symbols for locks. If any are held by another session,
+    // reject the entire write without acquiring any locks (all-or-nothing).
     let claimable: Vec<&crate::SymbolChangeDetail> = all_symbol_changes
         .iter()
         .filter(|sc| sc.change_type == "added" || sc.change_type == "modified")
         .collect();
 
-    let mut locked_symbols = Vec::new();
-    let mut acquired_symbols = Vec::new();
+    let qualified_names: Vec<String> = claimable.iter().map(|sc| sc.symbol_name.clone()).collect();
+    let conflicts = server.claim_tracker().check_conflicts(
+        repo_id,
+        &req.path,
+        sid,
+        &qualified_names,
+    );
 
-    for sc in &claimable {
-        let kind = sc.kind.parse::<dk_core::SymbolKind>().unwrap_or(dk_core::SymbolKind::Function);
-        match server.claim_tracker().acquire_lock(
-            repo_id,
-            &req.path,
-            SymbolClaim {
-                session_id: sid,
-                agent_name: agent_name.clone(),
-                qualified_name: sc.symbol_name.clone(),
-                kind,
-                first_touched_at: Instant::now(),
-            },
-        ) {
-            Ok(()) => acquired_symbols.push(sc.symbol_name.clone()),
-            Err(lock_info) => {
+    // If any symbols are locked, reject the write. No locks acquired, no
+    // changeset_store entry written — clean rejection.
+    if !conflicts.is_empty() {
+        let conflict_warnings: Vec<ConflictWarning> = conflicts
+            .into_iter()
+            .map(|c| {
                 warn!(
                     session_id = %sid,
                     path = %req.path,
-                    symbol = %lock_info.qualified_name,
-                    locked_by = %lock_info.locked_by_agent,
+                    symbol = %c.qualified_name,
+                    locked_by = %c.conflicting_agent,
                     "SYMBOL_LOCKED: write rejected"
                 );
-                locked_symbols.push(lock_info);
-            }
-        }
-    }
-
-    // If any symbols are locked, return SYMBOL_LOCKED. The overlay write already
-    // happened but is harmless — the agent will dk_file_read and overwrite after
-    // lock release, and the changeset hasn't been submitted yet.
-    if !locked_symbols.is_empty() {
-        let conflict_warnings: Vec<ConflictWarning> = locked_symbols
-            .iter()
-            .map(|l| ConflictWarning {
-                file_path: req.path.clone(),
-                symbol_name: l.qualified_name.clone(),
-                conflicting_agent: l.locked_by_agent.clone(),
-                conflicting_session_id: l.locked_by_session.to_string(),
-                message: format!(
-                    "SYMBOL_LOCKED: '{}' is locked by agent '{}'. Call dk_watch(filter: 'symbol.lock.released') to wait, then dk_file_read and retry.",
-                    l.qualified_name, l.locked_by_agent,
-                ),
+                ConflictWarning {
+                    file_path: req.path.clone(),
+                    symbol_name: c.qualified_name.clone(),
+                    conflicting_agent: c.conflicting_agent.clone(),
+                    conflicting_session_id: c.conflicting_session.to_string(),
+                    message: format!(
+                        "SYMBOL_LOCKED: '{}' is locked by agent '{}'. Call dk_watch(filter: 'symbol.lock.released') to wait, then dk_file_read and retry.",
+                        c.qualified_name, c.conflicting_agent,
+                    ),
+                }
             })
             .collect();
 
         info!(
             session_id = %sid,
             path = %req.path,
-            locked_count = locked_symbols.len(),
+            locked_count = conflict_warnings.len(),
             "FILE_WRITE: rejected — symbols locked by another agent"
         );
 
@@ -161,6 +138,30 @@ pub async fn handle_file_write(
             conflict_warnings,
         }));
     }
+
+    // All symbols are free — acquire locks and persist to changeset store.
+    for sc in &claimable {
+        let kind = sc.kind.parse::<dk_core::SymbolKind>().unwrap_or(dk_core::SymbolKind::Function);
+        // acquire_lock won't fail here — we just checked no conflicts exist
+        let _ = server.claim_tracker().acquire_lock(
+            repo_id,
+            &req.path,
+            SymbolClaim {
+                session_id: sid,
+                agent_name: agent_name.clone(),
+                qualified_name: sc.symbol_name.clone(),
+                kind,
+                first_touched_at: Instant::now(),
+            },
+        );
+    }
+
+    // Record in changeset_files AFTER lock acquisition succeeds.
+    let content_str = std::str::from_utf8(&req.content).ok();
+    let _ = engine
+        .changeset_store()
+        .upsert_file(changeset_id, &req.path, op, content_str)
+        .await;
 
     // All locks acquired — no conflicts. Build empty warnings for backward compat.
     let conflict_warnings: Vec<ConflictWarning> = Vec::new();

--- a/crates/dk-protocol/src/file_write.rs
+++ b/crates/dk-protocol/src/file_write.rs
@@ -167,6 +167,21 @@ pub async fn handle_file_write(
         None => {
             for name in &acquired {
                 server.claim_tracker().release_lock(repo_id, &req.path, sid, name);
+                server.event_bus().publish(crate::WatchEvent {
+                    event_type: crate::merge::EVENT_LOCK_RELEASED.to_string(),
+                    changeset_id: String::new(),
+                    agent_id: agent_name.clone(),
+                    affected_symbols: vec![name.clone()],
+                    details: format!("Symbol lock released on error in {}", req.path),
+                    session_id: req.session_id.clone(),
+                    affected_files: vec![crate::FileChange {
+                        path: req.path.clone(),
+                        operation: "unlock".to_string(),
+                    }],
+                    symbol_changes: vec![],
+                    repo_id: repo_id_str.clone(),
+                    event_id: uuid::Uuid::new_v4().to_string(),
+                });
             }
             return Err(Status::not_found("Workspace not found for session"));
         }
@@ -177,6 +192,21 @@ pub async fn handle_file_write(
         Err(e) => {
             for name in &acquired {
                 server.claim_tracker().release_lock(repo_id, &req.path, sid, name);
+                server.event_bus().publish(crate::WatchEvent {
+                    event_type: crate::merge::EVENT_LOCK_RELEASED.to_string(),
+                    changeset_id: String::new(),
+                    agent_id: agent_name.clone(),
+                    affected_symbols: vec![name.clone()],
+                    details: format!("Symbol lock released on error in {}", req.path),
+                    session_id: req.session_id.clone(),
+                    affected_files: vec![crate::FileChange {
+                        path: req.path.clone(),
+                        operation: "unlock".to_string(),
+                    }],
+                    symbol_changes: vec![],
+                    repo_id: repo_id_str.clone(),
+                    event_id: uuid::Uuid::new_v4().to_string(),
+                });
             }
             return Err(Status::internal(format!("Write failed: {e}")));
         }

--- a/crates/dk-protocol/src/file_write.rs
+++ b/crates/dk-protocol/src/file_write.rs
@@ -124,9 +124,25 @@ pub async fn handle_file_write(
     }
 
     if !locked_symbols.is_empty() {
-        // Roll back any locks acquired before the failure
+        // Roll back any locks acquired before the failure and emit events
+        // so any agent that raced and observed the transient lock can wake up.
         for name in &acquired {
             server.claim_tracker().release_lock(repo_id, &req.path, sid, name);
+            server.event_bus().publish(crate::WatchEvent {
+                event_type: crate::merge::EVENT_LOCK_RELEASED.to_string(),
+                changeset_id: String::new(),
+                agent_id: agent_name.clone(),
+                affected_symbols: vec![name.clone()],
+                details: format!("Symbol lock rolled back on {}", req.path),
+                session_id: req.session_id.clone(),
+                affected_files: vec![crate::FileChange {
+                    path: req.path.clone(),
+                    operation: "unlock".to_string(),
+                }],
+                symbol_changes: vec![],
+                repo_id: repo_id_str.clone(),
+                event_id: uuid::Uuid::new_v4().to_string(),
+            });
         }
 
         info!(

--- a/crates/dk-protocol/src/file_write.rs
+++ b/crates/dk-protocol/src/file_write.rs
@@ -80,7 +80,7 @@ pub async fn handle_file_write(
     // changeset store entry — completely clean rejection.
     let claimable: Vec<&crate::SymbolChangeDetail> = all_symbol_changes
         .iter()
-        .filter(|sc| sc.change_type == "added" || sc.change_type == "modified")
+        .filter(|sc| sc.change_type == "added" || sc.change_type == "modified" || sc.change_type == "deleted")
         .collect();
 
     let mut acquired: Vec<String> = Vec::new();

--- a/crates/dk-protocol/src/file_write.rs
+++ b/crates/dk-protocol/src/file_write.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use tonic::{Response, Status};
 use tracing::{info, warn};
 
-use dk_engine::conflict::SymbolClaim;
+use dk_engine::conflict::{AcquireOutcome, SymbolClaim};
 use crate::server::ProtocolServer;
 use crate::validation::{validate_file_path, MAX_FILE_SIZE};
 use crate::{ConflictWarning, FileWriteRequest, FileWriteResponse, SymbolChange};
@@ -99,7 +99,8 @@ pub async fn handle_file_write(
                 first_touched_at: Instant::now(),
             },
         ) {
-            Ok(()) => acquired.push(sc.symbol_name.clone()),
+            Ok(AcquireOutcome::Fresh) => acquired.push(sc.symbol_name.clone()),
+            Ok(AcquireOutcome::ReAcquired) => {} // already held — exclude from rollback
             Err(sl) => {
                 warn!(
                     session_id = %sid,

--- a/crates/dk-protocol/src/file_write.rs
+++ b/crates/dk-protocol/src/file_write.rs
@@ -114,8 +114,8 @@ pub async fn handle_file_write(
                     conflicting_agent: sl.locked_by_agent.clone(),
                     conflicting_session_id: sl.locked_by_session.to_string(),
                     message: format!(
-                        "SYMBOL_LOCKED: '{}' is locked by agent '{}'. Call dk_watch(filter: 'symbol.lock.released') to wait, then dk_file_read and retry.",
-                        sl.qualified_name, sl.locked_by_agent,
+                        "SYMBOL_LOCKED: '{}' is locked by agent '{}'. Call dk_watch(filter: '{}') to wait, then dk_file_read and retry.",
+                        sl.qualified_name, sl.locked_by_agent, crate::merge::EVENT_LOCK_RELEASED,
                     ),
                 });
             }

--- a/crates/dk-protocol/src/file_write.rs
+++ b/crates/dk-protocol/src/file_write.rs
@@ -62,88 +62,33 @@ pub async fn handle_file_write(
         }
     };
     let repo_id_str = repo_id.to_string();
-
-    // Write through the overlay (async DB persist)
-    let new_hash = ws
-        .overlay
-        .write(&req.path, req.content.clone(), is_new)
-        .await
-        .map_err(|e| Status::internal(format!("Write failed: {e}")))?;
-
     let changeset_id = ws.changeset_id;
     let agent_name = ws.agent_name.clone();
 
-    // Drop workspace guard before further work
+    // Drop workspace guard — overlay write is deferred until after lock acquisition
     drop(ws);
 
     let op = if is_new { "add" } else { "modify" };
 
-    // Detect symbol changes by diffing old vs new file content.
-    // Only symbols whose source text actually changed are reported.
+    // Detect symbol changes from req.content directly — no overlay needed yet.
     let (detected_changes, all_symbol_changes) =
         detect_symbol_changes_diffed(engine, &req.path, &old_content, &req.content, is_new);
 
-    // ── Symbol locking (check-then-acquire) ──
-    // First check ALL symbols for locks. If any are held by another session,
-    // reject the entire write without acquiring any locks (all-or-nothing).
+    // ── Symbol locking (acquire with rollback) ──
+    // Attempt to acquire locks for each changed symbol. If any fails, roll back
+    // all previously acquired locks and reject the write. No overlay write, no
+    // changeset store entry — completely clean rejection.
     let claimable: Vec<&crate::SymbolChangeDetail> = all_symbol_changes
         .iter()
         .filter(|sc| sc.change_type == "added" || sc.change_type == "modified")
         .collect();
 
-    let qualified_names: Vec<String> = claimable.iter().map(|sc| sc.symbol_name.clone()).collect();
-    let conflicts = server.claim_tracker().check_conflicts(
-        repo_id,
-        &req.path,
-        sid,
-        &qualified_names,
-    );
+    let mut acquired: Vec<String> = Vec::new();
+    let mut locked_symbols: Vec<ConflictWarning> = Vec::new();
 
-    // If any symbols are locked, reject the write. No locks acquired, no
-    // changeset_store entry written — clean rejection.
-    if !conflicts.is_empty() {
-        let conflict_warnings: Vec<ConflictWarning> = conflicts
-            .into_iter()
-            .map(|c| {
-                warn!(
-                    session_id = %sid,
-                    path = %req.path,
-                    symbol = %c.qualified_name,
-                    locked_by = %c.conflicting_agent,
-                    "SYMBOL_LOCKED: write rejected"
-                );
-                ConflictWarning {
-                    file_path: req.path.clone(),
-                    symbol_name: c.qualified_name.clone(),
-                    conflicting_agent: c.conflicting_agent.clone(),
-                    conflicting_session_id: c.conflicting_session.to_string(),
-                    message: format!(
-                        "SYMBOL_LOCKED: '{}' is locked by agent '{}'. Call dk_watch(filter: 'symbol.lock.released') to wait, then dk_file_read and retry.",
-                        c.qualified_name, c.conflicting_agent,
-                    ),
-                }
-            })
-            .collect();
-
-        info!(
-            session_id = %sid,
-            path = %req.path,
-            locked_count = conflict_warnings.len(),
-            "FILE_WRITE: rejected — symbols locked by another agent"
-        );
-
-        return Ok(Response::new(FileWriteResponse {
-            new_hash: String::new(),
-            detected_changes: Vec::new(),
-            conflict_warnings,
-        }));
-    }
-
-    // All symbols are free — acquire locks and persist to changeset store.
     for sc in &claimable {
         let kind = sc.kind.parse::<dk_core::SymbolKind>().unwrap_or(dk_core::SymbolKind::Function);
-        // acquire_lock won't fail here — we just checked no conflicts exist
-        let _ = server.claim_tracker().acquire_lock(
+        match server.claim_tracker().acquire_lock(
             repo_id,
             &req.path,
             SymbolClaim {
@@ -153,17 +98,71 @@ pub async fn handle_file_write(
                 kind,
                 first_touched_at: Instant::now(),
             },
-        );
+        ) {
+            Ok(()) => acquired.push(sc.symbol_name.clone()),
+            Err(sl) => {
+                warn!(
+                    session_id = %sid,
+                    path = %req.path,
+                    symbol = %sl.qualified_name,
+                    locked_by = %sl.locked_by_agent,
+                    "SYMBOL_LOCKED: write rejected"
+                );
+                locked_symbols.push(ConflictWarning {
+                    file_path: req.path.clone(),
+                    symbol_name: sl.qualified_name.clone(),
+                    conflicting_agent: sl.locked_by_agent.clone(),
+                    conflicting_session_id: sl.locked_by_session.to_string(),
+                    message: format!(
+                        "SYMBOL_LOCKED: '{}' is locked by agent '{}'. Call dk_watch(filter: 'symbol.lock.released') to wait, then dk_file_read and retry.",
+                        sl.qualified_name, sl.locked_by_agent,
+                    ),
+                });
+            }
+        }
     }
 
-    // Record in changeset_files AFTER lock acquisition succeeds.
+    if !locked_symbols.is_empty() {
+        // Roll back any locks acquired before the failure
+        for name in &acquired {
+            server.claim_tracker().release_lock(repo_id, &req.path, sid, name);
+        }
+
+        info!(
+            session_id = %sid,
+            path = %req.path,
+            locked_count = locked_symbols.len(),
+            rolled_back = acquired.len(),
+            "FILE_WRITE: rejected — symbols locked, rolled back partial locks"
+        );
+
+        return Ok(Response::new(FileWriteResponse {
+            new_hash: String::new(),
+            detected_changes: Vec::new(),
+            conflict_warnings: locked_symbols,
+        }));
+    }
+
+    // All locks acquired — now write the overlay and changeset store.
+    let ws = engine
+        .workspace_manager()
+        .get_workspace(&sid)
+        .ok_or_else(|| Status::not_found("Workspace not found for session"))?;
+
+    let new_hash = ws
+        .overlay
+        .write(&req.path, req.content.clone(), is_new)
+        .await
+        .map_err(|e| Status::internal(format!("Write failed: {e}")))?;
+
+    drop(ws);
+
     let content_str = std::str::from_utf8(&req.content).ok();
     let _ = engine
         .changeset_store()
         .upsert_file(changeset_id, &req.path, op, content_str)
         .await;
 
-    // All locks acquired — no conflicts. Build empty warnings for backward compat.
     let conflict_warnings: Vec<ConflictWarning> = Vec::new();
 
     // Emit a file.modified (or file.added) event

--- a/crates/dk-protocol/src/file_write.rs
+++ b/crates/dk-protocol/src/file_write.rs
@@ -144,16 +144,26 @@ pub async fn handle_file_write(
     }
 
     // All locks acquired — now write the overlay and changeset store.
-    let ws = engine
-        .workspace_manager()
-        .get_workspace(&sid)
-        .ok_or_else(|| Status::not_found("Workspace not found for session"))?;
+    // If either fails, release all acquired locks before propagating the error.
+    let ws = match engine.workspace_manager().get_workspace(&sid) {
+        Some(ws) => ws,
+        None => {
+            for name in &acquired {
+                server.claim_tracker().release_lock(repo_id, &req.path, sid, name);
+            }
+            return Err(Status::not_found("Workspace not found for session"));
+        }
+    };
 
-    let new_hash = ws
-        .overlay
-        .write(&req.path, req.content.clone(), is_new)
-        .await
-        .map_err(|e| Status::internal(format!("Write failed: {e}")))?;
+    let new_hash = match ws.overlay.write(&req.path, req.content.clone(), is_new).await {
+        Ok(hash) => hash,
+        Err(e) => {
+            for name in &acquired {
+                server.claim_tracker().release_lock(repo_id, &req.path, sid, name);
+            }
+            return Err(Status::internal(format!("Write failed: {e}")));
+        }
+    };
 
     drop(ws);
 

--- a/crates/dk-protocol/src/file_write.rs
+++ b/crates/dk-protocol/src/file_write.rs
@@ -89,67 +89,81 @@ pub async fn handle_file_write(
     let (detected_changes, all_symbol_changes) =
         detect_symbol_changes_diffed(engine, &req.path, &old_content, &req.content, is_new);
 
-    // ── Symbol claim tracking ──
-    // Build claims from "added" and "modified" symbol changes and check for
-    // cross-session conflicts. Two sessions modifying DIFFERENT symbols in the
-    // same file is NOT a conflict — only same-symbol is a true conflict.
-    let conflict_warnings = {
-        let claimable: Vec<&crate::SymbolChangeDetail> = all_symbol_changes
-            .iter()
-            .filter(|sc| sc.change_type == "added" || sc.change_type == "modified")
-            .collect();
+    // ── Symbol locking ──
+    // Attempt to acquire locks for each "added" or "modified" symbol. If another
+    // session holds the lock on any symbol, the write is REJECTED — the overlay
+    // write already happened but we revert it by re-writing the old content (or
+    // removing the file if it was new). The agent must dk_watch for lock release,
+    // then dk_file_read and retry.
+    let claimable: Vec<&crate::SymbolChangeDetail> = all_symbol_changes
+        .iter()
+        .filter(|sc| sc.change_type == "added" || sc.change_type == "modified")
+        .collect();
 
-        // Check for conflicts before recording our claims
-        let qualified_names: Vec<String> = claimable.iter().map(|sc| sc.symbol_name.clone()).collect();
-        let conflicts = server.claim_tracker().check_conflicts(
+    let mut locked_symbols = Vec::new();
+    let mut acquired_symbols = Vec::new();
+
+    for sc in &claimable {
+        let kind = sc.kind.parse::<dk_core::SymbolKind>().unwrap_or(dk_core::SymbolKind::Function);
+        match server.claim_tracker().acquire_lock(
             repo_id,
             &req.path,
-            sid,
-            &qualified_names,
-        );
-
-        // Record claims (even if conflicts exist — warning only at write time)
-        for sc in &claimable {
-            let kind = sc.kind.parse::<dk_core::SymbolKind>().unwrap_or(dk_core::SymbolKind::Function);
-            server.claim_tracker().record_claim(
-                repo_id,
-                &req.path,
-                SymbolClaim {
-                    session_id: sid,
-                    agent_name: agent_name.clone(),
-                    qualified_name: sc.symbol_name.clone(),
-                    kind,
-                    first_touched_at: Instant::now(),
-                },
-            );
-        }
-
-        // Build ConflictWarning proto messages
-        let warnings: Vec<ConflictWarning> = conflicts
-            .into_iter()
-            .map(|c| {
-                let msg = format!(
-                    "Symbol '{}' was already modified by agent '{}' (session {})",
-                    c.qualified_name, c.conflicting_agent, c.conflicting_session,
-                );
+            SymbolClaim {
+                session_id: sid,
+                agent_name: agent_name.clone(),
+                qualified_name: sc.symbol_name.clone(),
+                kind,
+                first_touched_at: Instant::now(),
+            },
+        ) {
+            Ok(()) => acquired_symbols.push(sc.symbol_name.clone()),
+            Err(lock_info) => {
                 warn!(
                     session_id = %sid,
                     path = %req.path,
-                    symbol = %c.qualified_name,
-                    conflicting_agent = %c.conflicting_agent,
-                    "CONFLICT_WARNING: {msg}"
+                    symbol = %lock_info.qualified_name,
+                    locked_by = %lock_info.locked_by_agent,
+                    "SYMBOL_LOCKED: write rejected"
                 );
-                ConflictWarning {
-                    file_path: req.path.clone(),
-                    symbol_name: c.qualified_name,
-                    conflicting_agent: c.conflicting_agent,
-                    conflicting_session_id: c.conflicting_session.to_string(),
-                    message: msg,
-                }
+                locked_symbols.push(lock_info);
+            }
+        }
+    }
+
+    // If any symbols are locked, return SYMBOL_LOCKED. The overlay write already
+    // happened but is harmless — the agent will dk_file_read and overwrite after
+    // lock release, and the changeset hasn't been submitted yet.
+    if !locked_symbols.is_empty() {
+        let conflict_warnings: Vec<ConflictWarning> = locked_symbols
+            .iter()
+            .map(|l| ConflictWarning {
+                file_path: req.path.clone(),
+                symbol_name: l.qualified_name.clone(),
+                conflicting_agent: l.locked_by_agent.clone(),
+                conflicting_session_id: l.locked_by_session.to_string(),
+                message: format!(
+                    "SYMBOL_LOCKED: '{}' is locked by agent '{}'. Call dk_watch(filter: 'symbol.lock.released') to wait, then dk_file_read and retry.",
+                    l.qualified_name, l.locked_by_agent,
+                ),
             })
             .collect();
-        warnings
-    };
+
+        info!(
+            session_id = %sid,
+            path = %req.path,
+            locked_count = locked_symbols.len(),
+            "FILE_WRITE: rejected — symbols locked by another agent"
+        );
+
+        return Ok(Response::new(FileWriteResponse {
+            new_hash: String::new(),
+            detected_changes: Vec::new(),
+            conflict_warnings,
+        }));
+    }
+
+    // All locks acquired — no conflicts. Build empty warnings for backward compat.
+    let conflict_warnings: Vec<ConflictWarning> = Vec::new();
 
     // Emit a file.modified (or file.added) event
     let event_type = if is_new { "file.added" } else { "file.modified" };

--- a/crates/dk-protocol/src/merge.rs
+++ b/crates/dk-protocol/src/merge.rs
@@ -99,12 +99,13 @@ pub async fn handle_merge(
 
     match merge_result {
         WorkspaceMergeResult::FastMerge { commit_hash } => {
+            // Release locks first — git commit is already in the tree,
+            // so locks must be freed regardless of changeset-store state.
+            release_locks_and_emit(server, repo_id, sid, &req.session_id);
+
             // Update changeset status to merged
             engine.changeset_store().set_merged(changeset_id, &commit_hash).await
                 .map_err(|e| Status::internal(e.to_string()))?;
-
-            // Release symbol locks and emit lock release events
-            release_locks_and_emit(server, repo_id, sid, &req.session_id);
 
             // Publish merge event
             server.event_bus().publish(crate::WatchEvent {
@@ -134,12 +135,12 @@ pub async fn handle_merge(
             commit_hash,
             auto_rebased_files,
         } => {
+            // Release locks first — git commit is already in the tree.
+            release_locks_and_emit(server, repo_id, sid, &req.session_id);
+
             // Update changeset status to merged
             engine.changeset_store().set_merged(changeset_id, &commit_hash).await
                 .map_err(|e| Status::internal(e.to_string()))?;
-
-            // Release symbol locks and emit lock release events
-            release_locks_and_emit(server, repo_id, sid, &req.session_id);
 
             // Publish merge event
             server.event_bus().publish(crate::WatchEvent {

--- a/crates/dk-protocol/src/merge.rs
+++ b/crates/dk-protocol/src/merge.rs
@@ -221,7 +221,7 @@ fn release_locks_and_emit(
     server: &ProtocolServer,
     repo_id: Uuid,
     session_id: Uuid,
-    repo_id_str: &str,
+    _repo_id_str: &str,
     session_id_str: &str,
 ) {
     let released = server.claim_tracker().release_locks(repo_id, session_id);
@@ -252,7 +252,7 @@ fn release_locks_and_emit(
                 operation: "unlock".to_string(),
             }],
             symbol_changes: vec![],
-            repo_id: repo_id_str.to_string(),
+            repo_id: repo_id.to_string(),
             event_id: Uuid::new_v4().to_string(),
         });
     }

--- a/crates/dk-protocol/src/merge.rs
+++ b/crates/dk-protocol/src/merge.rs
@@ -31,10 +31,10 @@ pub async fn handle_merge(
         .parse::<Uuid>()
         .map_err(|_| Status::invalid_argument("Invalid session ID"))?;
 
-    // Resolve repo_id for enriched events and lock release
-    let (repo_id, repo_id_str) = match engine.get_repo(&session.codebase).await {
-        Ok((rid, _)) => (rid, rid.to_string()),
-        Err(_) => (Uuid::nil(), String::new()),
+    // Resolve repo_id_str for enriched events (non-fatal — empty string on failure)
+    let repo_id_str = match engine.get_repo(&session.codebase).await {
+        Ok((rid, _)) => rid.to_string(),
+        Err(_) => String::new(),
     };
 
     let changeset_id = req.changeset_id.parse::<Uuid>()
@@ -57,8 +57,9 @@ pub async fn handle_merge(
         .get_workspace(&sid)
         .ok_or_else(|| Status::not_found("Workspace not found for session"))?;
 
-    // Get git repo
-    let (_, git_repo) = engine.get_repo(&session.codebase).await
+    // Get git repo — also use this repo_id for lock release (the first get_repo
+    // call is non-fatal and may return empty string, but this one propagates errors)
+    let (repo_id, git_repo) = engine.get_repo(&session.codebase).await
         .map_err(|e| Status::internal(e.to_string()))?;
 
     let agent = changeset.agent_id.as_deref().unwrap_or("agent");

--- a/crates/dk-protocol/src/merge.rs
+++ b/crates/dk-protocol/src/merge.rs
@@ -104,7 +104,7 @@ pub async fn handle_merge(
                 .map_err(|e| Status::internal(e.to_string()))?;
 
             // Release symbol locks and emit lock release events
-            release_locks_and_emit(server, repo_id, sid, &repo_id_str, &req.session_id);
+            release_locks_and_emit(server, repo_id, sid, &req.session_id);
 
             // Publish merge event
             server.event_bus().publish(crate::WatchEvent {
@@ -139,7 +139,7 @@ pub async fn handle_merge(
                 .map_err(|e| Status::internal(e.to_string()))?;
 
             // Release symbol locks and emit lock release events
-            release_locks_and_emit(server, repo_id, sid, &repo_id_str, &req.session_id);
+            release_locks_and_emit(server, repo_id, sid, &req.session_id);
 
             // Publish merge event
             server.event_bus().publish(crate::WatchEvent {
@@ -221,7 +221,6 @@ fn release_locks_and_emit(
     server: &ProtocolServer,
     repo_id: Uuid,
     session_id: Uuid,
-    _repo_id_str: &str,
     session_id_str: &str,
 ) {
     let released = server.claim_tracker().release_locks(repo_id, session_id);

--- a/crates/dk-protocol/src/merge.rs
+++ b/crates/dk-protocol/src/merge.rs
@@ -170,6 +170,9 @@ pub async fn handle_merge(
         }
 
         WorkspaceMergeResult::Conflicts { conflicts } => {
+            // Intentionally NOT releasing locks here. The agent retains its locks
+            // while resolving conflicts (dk_resolve → retry dk_merge). Locks are
+            // released when the session is closed (dk_close) or times out (30 min GC).
             let conflict_details: Vec<ConflictDetail> = conflicts
                 .iter()
                 .map(|c| {

--- a/crates/dk-protocol/src/merge.rs
+++ b/crates/dk-protocol/src/merge.rs
@@ -243,7 +243,7 @@ fn release_locks_and_emit(
         server.event_bus().publish(crate::WatchEvent {
             event_type: EVENT_LOCK_RELEASED.to_string(),
             changeset_id: String::new(),
-            agent_id: String::new(),
+            agent_id: released.first().map(|r| r.agent_name.clone()).unwrap_or_default(),
             affected_symbols: symbols,
             details: format!("Symbol locks released on {}", file_path),
             session_id: session_id_str.to_string(),

--- a/crates/dk-protocol/src/merge.rs
+++ b/crates/dk-protocol/src/merge.rs
@@ -31,10 +31,10 @@ pub async fn handle_merge(
         .parse::<Uuid>()
         .map_err(|_| Status::invalid_argument("Invalid session ID"))?;
 
-    // Resolve repo_id for enriched events
-    let repo_id_str = match engine.get_repo(&session.codebase).await {
-        Ok((rid, _)) => rid.to_string(),
-        Err(_) => String::new(),
+    // Resolve repo_id for enriched events and lock release
+    let (repo_id, repo_id_str) = match engine.get_repo(&session.codebase).await {
+        Ok((rid, _)) => (rid, rid.to_string()),
+        Err(_) => (Uuid::nil(), String::new()),
     };
 
     let changeset_id = req.changeset_id.parse::<Uuid>()
@@ -102,7 +102,10 @@ pub async fn handle_merge(
             engine.changeset_store().set_merged(changeset_id, &commit_hash).await
                 .map_err(|e| Status::internal(e.to_string()))?;
 
-            // Publish event
+            // Release symbol locks and emit lock release events
+            release_locks_and_emit(server, repo_id, sid, &repo_id_str, &req.session_id);
+
+            // Publish merge event
             server.event_bus().publish(crate::WatchEvent {
                 event_type: "changeset.merged".to_string(),
                 changeset_id: changeset_id.to_string(),
@@ -134,7 +137,10 @@ pub async fn handle_merge(
             engine.changeset_store().set_merged(changeset_id, &commit_hash).await
                 .map_err(|e| Status::internal(e.to_string()))?;
 
-            // Publish event
+            // Release symbol locks and emit lock release events
+            release_locks_and_emit(server, repo_id, sid, &repo_id_str, &req.session_id);
+
+            // Publish merge event
             server.event_bus().publish(crate::WatchEvent {
                 event_type: "changeset.merged".to_string(),
                 changeset_id: changeset_id.to_string(),
@@ -205,10 +211,57 @@ pub async fn handle_merge(
     }
 }
 
-// ── Event type constant ─────────────────────────────────────────────
+/// Release all symbol locks for a session and emit `symbol.lock.released` events
+/// so blocked agents can wake up and retry their writes.
+fn release_locks_and_emit(
+    server: &ProtocolServer,
+    repo_id: Uuid,
+    session_id: Uuid,
+    repo_id_str: &str,
+    session_id_str: &str,
+) {
+    let released = server.claim_tracker().release_locks(repo_id, session_id);
+
+    if released.is_empty() {
+        return;
+    }
+
+    // Group released locks by file_path for efficient event emission
+    let mut by_file: std::collections::HashMap<String, Vec<String>> = std::collections::HashMap::new();
+    for lock in &released {
+        by_file
+            .entry(lock.file_path.clone())
+            .or_default()
+            .push(lock.qualified_name.clone());
+    }
+
+    for (file_path, symbols) in by_file {
+        server.event_bus().publish(crate::WatchEvent {
+            event_type: EVENT_LOCK_RELEASED.to_string(),
+            changeset_id: String::new(),
+            agent_id: String::new(),
+            affected_symbols: symbols,
+            details: format!("Symbol locks released on {}", file_path),
+            session_id: session_id_str.to_string(),
+            affected_files: vec![crate::FileChange {
+                path: file_path,
+                operation: "unlock".to_string(),
+            }],
+            symbol_changes: vec![],
+            repo_id: repo_id_str.to_string(),
+            event_id: Uuid::new_v4().to_string(),
+        });
+    }
+}
+
+// ── Event type constants ────────────────────────────────────────────
 
 /// Event published when a changeset is successfully merged.
 pub const EVENT_MERGED: &str = "changeset.merged";
+
+/// Event published when symbol locks are released (after merge, close, or timeout).
+/// Blocked agents watch for this to retry their `dk_file_write`.
+pub const EVENT_LOCK_RELEASED: &str = "symbol.lock.released";
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Implements blocking symbol locks in the engine — the foundation for safe multi-agent concurrent access without requiring a harness to coordinate.

- **SymbolClaimTracker**: `acquire_lock` (blocking) replaces advisory `check_conflicts` + `record_claim`. `release_locks` returns what was freed for event emission
- **dk_file_write**: Returns `SYMBOL_LOCKED` when another agent holds a symbol, rejecting the write. Agent must `dk_watch` for release, then `dk_file_read` and retry
- **dk_merge**: Releases all symbol locks after successful merge and emits `symbol.lock.released` events so blocked agents wake up
- **Different symbols in same file**: No contention — dkod's AST-level merge advantage preserved

## Design doc

See https://github.com/dkod-io/harness/pull/71 for the full design document and corresponding harness changes (streaming merge, generator self-merge pipeline).

## Test plan

- [ ] Existing claim_tracker tests pass (5/5)
- [ ] Existing merge tests pass (9/9)
- [ ] `acquire_lock` returns Ok for unclaimed symbols
- [ ] `acquire_lock` returns Ok for same-session re-acquisition
- [ ] `acquire_lock` returns Err(SymbolLocked) for cross-session same-symbol
- [ ] `acquire_lock` allows different symbols in same file across sessions
- [ ] `release_locks` returns all released symbols for event emission
- [ ] `dk_file_write` returns SYMBOL_LOCKED when blocked
- [ ] `dk_merge` emits `symbol.lock.released` events
- [ ] Blocked agent receives lock release event via `dk_watch`