### PR TITLE
fix: sanitize null bytes in conflict payload fields

### DIFF
--- a/crates/dk-core/src/lib.rs
+++ b/crates/dk-core/src/lib.rs
@@ -7,6 +7,15 @@ pub mod types;
 pub use error::{Error, Result};
 pub use types::*;
 
+// ── String sanitization ──
+
+/// Strip null bytes from strings before protobuf/JSON serialization.
+/// Tree-sitter AST parsing can produce null bytes from lossy UTF-8 conversion;
+/// these break protobuf string fields and JSON encoding.
+pub fn sanitize_for_proto(s: &str) -> String {
+    s.replace('\0', "")
+}
+
 // ── Git author helpers ──
 
 /// Strip characters that would corrupt a raw git commit-object header.
@@ -41,6 +50,20 @@ pub fn resolve_author(name: &str, email: &str, agent: &str) -> (String, String) 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sanitize_for_proto_strips_null_bytes() {
+        assert_eq!(sanitize_for_proto("hello\0world"), "helloworld");
+        assert_eq!(sanitize_for_proto("\0\0"), "");
+        assert_eq!(sanitize_for_proto("clean"), "clean");
+    }
+
+    #[test]
+    fn sanitize_for_proto_preserves_valid_utf8() {
+        assert_eq!(sanitize_for_proto("fn résumé()"), "fn résumé()");
+        assert_eq!(sanitize_for_proto("日本語"), "日本語");
+        assert_eq!(sanitize_for_proto("bad\u{FFFD}char"), "bad\u{FFFD}char");
+    }
 
     #[test]
     fn resolve_author_uses_supplied_values() {

--- a/crates/dk-engine/src/conflict/payload.rs
+++ b/crates/dk-engine/src/conflict/payload.rs
@@ -9,16 +9,9 @@ use std::path::Path;
 
 use serde::Serialize;
 
-use dk_core::{Error, Result, Symbol};
+use dk_core::{sanitize_for_proto, Error, Result, Symbol};
 
 use crate::parser::ParserRegistry;
-
-/// Strip null bytes from strings before serialization.
-/// Tree-sitter AST parsing can produce null bytes from lossy UTF-8 conversion;
-/// these break protobuf/JSON round-tripping.
-fn sanitize(s: &str) -> String {
-    s.replace('\0', "")
-}
 
 /// A block of conflicts to include in a SUBMIT response.
 #[derive(Debug, Clone, Serialize)]
@@ -251,10 +244,10 @@ pub fn build_conflict_detail(
     )?;
 
     Ok(SymbolConflictDetail {
-        file_path: sanitize(file_path),
-        qualified_name: sanitize(qualified_name),
-        kind: sanitize(&kind),
-        conflicting_agent: sanitize(conflicting_agent),
+        file_path: sanitize_for_proto(file_path),
+        qualified_name: sanitize_for_proto(qualified_name),
+        kind: sanitize_for_proto(&kind),
+        conflicting_agent: sanitize_for_proto(conflicting_agent),
         their_change,
         your_change,
         base_version,

--- a/crates/dk-engine/src/conflict/payload.rs
+++ b/crates/dk-engine/src/conflict/payload.rs
@@ -13,6 +13,13 @@ use dk_core::{Error, Result, Symbol};
 
 use crate::parser::ParserRegistry;
 
+/// Strip null bytes from strings before serialization.
+/// Tree-sitter AST parsing can produce null bytes from lossy UTF-8 conversion;
+/// these break protobuf/JSON round-tripping.
+fn sanitize(s: &str) -> String {
+    s.replace('\0', "")
+}
+
 /// A block of conflicts to include in a SUBMIT response.
 #[derive(Debug, Clone, Serialize)]
 pub struct ConflictBlock {
@@ -244,10 +251,10 @@ pub fn build_conflict_detail(
     )?;
 
     Ok(SymbolConflictDetail {
-        file_path: file_path.to_string(),
-        qualified_name: qualified_name.to_string(),
-        kind,
-        conflicting_agent: conflicting_agent.to_string(),
+        file_path: sanitize(file_path),
+        qualified_name: sanitize(qualified_name),
+        kind: sanitize(&kind),
+        conflicting_agent: sanitize(conflicting_agent),
         their_change,
         your_change,
         base_version,

--- a/crates/dk-protocol/src/merge.rs
+++ b/crates/dk-protocol/src/merge.rs
@@ -9,15 +9,7 @@ use crate::{merge_response, ConflictDetail, MergeConflict, MergeRequest, MergeRe
 /// Conflict type for true write-write semantic conflicts.
 const CONFLICT_TYPE_TRUE: &str = "true_conflict";
 
-/// Sanitize a string for protobuf `string` fields.
-///
-/// Rust `String` is guaranteed valid UTF-8, but content originating from
-/// tree-sitter AST parsing may contain null bytes or replacement characters
-/// from lossy conversions.  Strip null bytes so the value round-trips cleanly
-/// through protobuf serialization/deserialization.
-fn sanitize_for_proto(s: &str) -> String {
-    s.replace('\0', "")
-}
+use dk_core::sanitize_for_proto;
 
 pub async fn handle_merge(
     server: &ProtocolServer,


### PR DESCRIPTION
## Summary

Sanitizes `file_path`, `qualified_name`, `kind`, and `conflicting_agent` in `SymbolConflictDetail` construction to strip null bytes before serialization. Tree-sitter AST parsing can produce null bytes from lossy UTF-8 conversion, which break protobuf/JSON round-tripping.

This matches the sanitization already applied in `merge.rs::sanitize_for_proto()`.

Flagged in PR #60 review as a minor gap.

## Test plan

- [ ] Compiles clean
- [ ] Existing tests pass