### PR TITLE
fix: MCP bridge shows SYMBOL_LOCKED instead of generic warning

### DIFF
--- a/crates/dk-mcp/src/server.rs
+++ b/crates/dk-mcp/src/server.rs
@@ -1469,7 +1469,7 @@ impl DkodMcp {
             )
         };
 
-        if !response.detected_changes.is_empty() && !write_rejected {
+        if !response.detected_changes.is_empty() && !response.new_hash.is_empty() {
             text.push_str("\nDetected symbol changes:\n");
             for sc in &response.detected_changes {
                 text.push_str(&format!("  {} ({})\n", sc.symbol_name, sc.change_type));

--- a/crates/dk-mcp/src/server.rs
+++ b/crates/dk-mcp/src/server.rs
@@ -1454,21 +1454,24 @@ impl DkodMcp {
             .map_err(|e| McpError::internal_error(format!("FILE_WRITE RPC failed: {e}"), None))?
             .into_inner();
 
-        let mut text = format!(
-            "Wrote {bytes_written} bytes to {path}\nhash: {}\n",
-            response.new_hash,
-        );
+        // Distinguish SYMBOL_LOCKED (write rejected, empty hash) from advisory warnings
+        let write_rejected = response.new_hash.is_empty() && !response.conflict_warnings.is_empty();
 
-        if !response.detected_changes.is_empty() {
+        let mut text = if write_rejected {
+            format!("SYMBOL_LOCKED — write rejected for {path}\n\n")
+        } else {
+            format!(
+                "Wrote {bytes_written} bytes to {path}\nhash: {}\n",
+                response.new_hash,
+            )
+        };
+
+        if !response.detected_changes.is_empty() && !write_rejected {
             text.push_str("\nDetected symbol changes:\n");
             for sc in &response.detected_changes {
                 text.push_str(&format!("  {} ({})\n", sc.symbol_name, sc.change_type));
             }
             // Track modified symbols for watch event impact analysis.
-            // Key on file_path::symbol_name to avoid false-positive [AFFECTS YOUR WORK]
-            // tags for common names like "new" or "default" that appear across many modules.
-            // Normalize the path (strip leading "./") to match engine-normalized paths
-            // in WatchEvent.symbol_changes.file_path.
             {
                 let normalized_path = path.strip_prefix("./").unwrap_or(&path);
                 let mut map = self.my_modified_symbols.lock().await;
@@ -1480,14 +1483,28 @@ impl DkodMcp {
         }
 
         if !response.conflict_warnings.is_empty() {
-            text.push_str("\nCONFLICT WARNING:\n");
-            for cw in &response.conflict_warnings {
-                text.push_str(&format!(
-                    "  {} is also modifying {} in this file\n",
-                    cw.conflicting_agent, cw.symbol_name
-                ));
+            if write_rejected {
+                text.push_str("Locked symbols:\n");
+                for cw in &response.conflict_warnings {
+                    text.push_str(&format!(
+                        "  {} — locked by agent '{}'\n",
+                        cw.symbol_name, cw.conflicting_agent
+                    ));
+                }
+                text.push_str("\nYour write was NOT applied. To proceed:\n");
+                text.push_str("  1. dk_watch(filter: \"symbol.lock.released\", wait: true)\n");
+                text.push_str("  2. dk_file_read(path)  — get the merged version\n");
+                text.push_str("  3. dk_file_write(path, adapted_content)  — retry\n");
+            } else {
+                text.push_str("\nCONFLICT WARNING:\n");
+                for cw in &response.conflict_warnings {
+                    text.push_str(&format!(
+                        "  {} is also modifying {} in this file\n",
+                        cw.conflicting_agent, cw.symbol_name
+                    ));
+                }
+                text.push_str("Your changes may be rejected at SUBMIT time.\n");
             }
-            text.push_str("Your changes may be rejected at SUBMIT time.\n");
         }
 
         let prefix = self

--- a/crates/dk-mcp/src/server.rs
+++ b/crates/dk-mcp/src/server.rs
@@ -1456,9 +1456,12 @@ impl DkodMcp {
 
         // Distinguish SYMBOL_LOCKED (write rejected, empty hash) from advisory warnings
         let write_rejected = response.new_hash.is_empty() && !response.conflict_warnings.is_empty();
+        let silent_rejection = response.new_hash.is_empty() && response.conflict_warnings.is_empty();
 
         let mut text = if write_rejected {
             format!("SYMBOL_LOCKED — write rejected for {path}\n\n")
+        } else if silent_rejection {
+            format!("WRITE REJECTED — server returned no hash and no conflict details for {path}\n")
         } else {
             format!(
                 "Wrote {bytes_written} bytes to {path}\nhash: {}\n",


### PR DESCRIPTION
## Summary

When `dk_file_write` is rejected due to symbol locking (empty `new_hash` + `conflict_warnings`), the MCP bridge now shows a clear `SYMBOL_LOCKED` message with actionable instructions instead of the generic "CONFLICT WARNING" that misleadingly implied the write succeeded.

Before:
```
Wrote 243 bytes to src/stores/useTaskStore.ts
hash:

CONFLICT WARNING:
  test-agent-A is also modifying Task in this file
Your changes may be rejected at SUBMIT time.
```

After:
```
SYMBOL_LOCKED — write rejected for src/stores/useTaskStore.ts

Locked symbols:
  Task — locked by agent 'test-agent-A'

Your write was NOT applied. To proceed:
  1. dk_watch(filter: "symbol.lock.released", wait: true)
  2. dk_file_read(path)  — get the merged version
  3. dk_file_write(path, adapted_content)  — retry
```

## Test plan

- [ ] Same-symbol write from another session shows SYMBOL_LOCKED format
- [ ] Different-symbol write still shows normal success format
- [ ] Advisory warnings (if any remain) still show CONFLICT WARNING format