### PR TITLE
feat: Valkey-backed symbol locking for cross-pod coordination

### DIFF
--- a/crates/dk-engine/src/conflict/claim_tracker.rs
+++ b/crates/dk-engine/src/conflict/claim_tracker.rs
@@ -103,6 +103,12 @@ pub trait ClaimTracker: Send + Sync {
     ) -> Vec<ConflictInfo>;
 
     /// Return all conflicts for a session across all file paths.
+    ///
+    /// This method is only meaningful for the non-blocking `record_claim` path
+    /// where multiple sessions can record overlapping claims without rejection.
+    /// Backends that use exclusive locking (e.g. `ValkeyClaimTracker`) may
+    /// return an empty list since cross-session conflicts are prevented at
+    /// write time by `acquire_lock`.
     async fn get_all_conflicts_for_session(
         &self,
         repo_id: Uuid,

--- a/crates/dk-engine/src/conflict/claim_tracker.rs
+++ b/crates/dk-engine/src/conflict/claim_tracker.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
@@ -57,6 +58,65 @@ pub struct ReleasedLock {
     pub agent_name: String,
 }
 
+// ---------------------------------------------------------------------------
+// ClaimTracker trait
+// ---------------------------------------------------------------------------
+
+/// Async trait for symbol-level claim tracking across sessions.
+///
+/// Implementations:
+/// - [`LocalClaimTracker`] — in-memory DashMap (single-pod / tests)
+/// - `ValkeyClaimTracker` — Valkey/Redis-backed (multi-pod, behind `valkey` feature)
+#[async_trait]
+pub trait ClaimTracker: Send + Sync {
+    /// Record a symbol claim (non-blocking — does not reject on conflict).
+    async fn record_claim(&self, repo_id: Uuid, file_path: &str, claim: SymbolClaim);
+
+    /// Attempt to acquire a symbol lock. Returns `Err(SymbolLocked)` if
+    /// another session already holds the symbol.
+    async fn acquire_lock(
+        &self,
+        repo_id: Uuid,
+        file_path: &str,
+        claim: SymbolClaim,
+    ) -> Result<AcquireOutcome, SymbolLocked>;
+
+    /// Release a single symbol lock for a session in a specific file.
+    async fn release_lock(
+        &self,
+        repo_id: Uuid,
+        file_path: &str,
+        session_id: Uuid,
+        qualified_name: &str,
+    );
+
+    /// Release all locks held by a session for a specific repo.
+    async fn release_locks(&self, repo_id: Uuid, session_id: Uuid) -> Vec<ReleasedLock>;
+
+    /// Check whether any of the given symbols conflict with another session.
+    async fn check_conflicts(
+        &self,
+        repo_id: Uuid,
+        file_path: &str,
+        session_id: Uuid,
+        qualified_names: &[String],
+    ) -> Vec<ConflictInfo>;
+
+    /// Return all conflicts for a session across all file paths.
+    async fn get_all_conflicts_for_session(
+        &self,
+        repo_id: Uuid,
+        session_id: Uuid,
+    ) -> Vec<(String, ConflictInfo)>;
+
+    /// Remove all claims belonging to a session across ALL repos.
+    async fn clear_session(&self, session_id: Uuid) -> Vec<ReleasedLock>;
+}
+
+// ---------------------------------------------------------------------------
+// LocalClaimTracker — in-memory DashMap implementation
+// ---------------------------------------------------------------------------
+
 /// Thread-safe, lock-free tracker for symbol-level claims across sessions.
 ///
 /// Key insight: two sessions modifying DIFFERENT symbols in the same file is
@@ -66,46 +126,43 @@ pub struct ReleasedLock {
 /// The tracker is keyed by `(repo_id, file_path)` and stores a `Vec<SymbolClaim>`
 /// for each file. DashMap provides fine-grained per-shard locking so reads are
 /// effectively lock-free when not contending on the same shard.
-pub struct SymbolClaimTracker {
+pub struct LocalClaimTracker {
     /// Map from (repo_id, file_path) to the list of claims on that file.
     claims: DashMap<(Uuid, String), Vec<SymbolClaim>>,
 }
 
-impl SymbolClaimTracker {
-    /// Create a new, empty tracker.
+impl LocalClaimTracker {
     pub fn new() -> Self {
         Self {
             claims: DashMap::new(),
         }
     }
+}
 
-    /// Record a symbol claim. If the same session already claims the same
-    /// `qualified_name` in the same file, the existing claim is updated
-    /// (not duplicated).
-    pub fn record_claim(&self, repo_id: Uuid, file_path: &str, claim: SymbolClaim) {
+impl Default for LocalClaimTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ClaimTracker for LocalClaimTracker {
+    async fn record_claim(&self, repo_id: Uuid, file_path: &str, claim: SymbolClaim) {
         let key = (repo_id, file_path.to_string());
         let mut entry = self.claims.entry(key).or_default();
         let claims = entry.value_mut();
 
-        // Deduplicate: same session + same qualified_name → update in place
         if let Some(existing) = claims.iter_mut().find(|c| {
             c.session_id == claim.session_id && c.qualified_name == claim.qualified_name
         }) {
             existing.kind = claim.kind;
             existing.agent_name = claim.agent_name;
-            // Keep the original first_touched_at
         } else {
             claims.push(claim);
         }
     }
 
-    /// Attempt to acquire a symbol lock. If the symbol is already claimed by
-    /// another session, returns `Err(SymbolLocked)` — the write MUST NOT proceed.
-    /// If claimed by the same session, or unclaimed, acquires and returns `Ok(())`.
-    ///
-    /// This is the blocking counterpart to `record_claim`. Use this when writes
-    /// should be rejected if another agent holds the symbol.
-    pub fn acquire_lock(
+    async fn acquire_lock(
         &self,
         repo_id: Uuid,
         file_path: &str,
@@ -115,7 +172,6 @@ impl SymbolClaimTracker {
         let mut entry = self.claims.entry(key).or_default();
         let claims = entry.value_mut();
 
-        // Check if another session already holds this symbol
         if let Some(existing) = claims.iter().find(|c| {
             c.qualified_name == claim.qualified_name && c.session_id != claim.session_id
         }) {
@@ -129,7 +185,6 @@ impl SymbolClaimTracker {
             });
         }
 
-        // Same session re-acquisition — update metadata, return ReAcquired
         if let Some(existing) = claims.iter_mut().find(|c| {
             c.session_id == claim.session_id && c.qualified_name == claim.qualified_name
         }) {
@@ -138,14 +193,11 @@ impl SymbolClaimTracker {
             return Ok(AcquireOutcome::ReAcquired);
         }
 
-        // Fresh claim
         claims.push(claim);
         Ok(AcquireOutcome::Fresh)
     }
 
-    /// Release a single symbol lock for a session in a specific file.
-    /// Used to roll back partially-acquired locks when a batch fails.
-    pub fn release_lock(
+    async fn release_lock(
         &self,
         repo_id: Uuid,
         file_path: &str,
@@ -158,13 +210,10 @@ impl SymbolClaimTracker {
                 !(c.session_id == session_id && c.qualified_name == qualified_name)
             });
         }
-        // Clean up empty entries to prevent unbounded growth from repeated rollbacks
         self.claims.remove_if(&key, |_, v| v.is_empty());
     }
 
-    /// Release all locks held by a session and return what was released.
-    /// Callers should emit `symbol.lock.released` events for each returned entry.
-    pub fn release_locks(&self, repo_id: Uuid, session_id: Uuid) -> Vec<ReleasedLock> {
+    async fn release_locks(&self, repo_id: Uuid, session_id: Uuid) -> Vec<ReleasedLock> {
         let mut released = Vec::new();
         let mut empty_keys = Vec::new();
 
@@ -176,7 +225,6 @@ impl SymbolClaimTracker {
             let file_path = &key.1;
             let claims = entry.value_mut();
 
-            // Collect released locks before removing
             for claim in claims.iter().filter(|c| c.session_id == session_id) {
                 released.push(ReleasedLock {
                     file_path: file_path.clone(),
@@ -199,10 +247,7 @@ impl SymbolClaimTracker {
         released
     }
 
-    /// Check whether any of the given `qualified_names` are already claimed by
-    /// a session other than `session_id`. Returns a `ConflictInfo` for each
-    /// conflicting symbol.
-    pub fn check_conflicts(
+    async fn check_conflicts(
         &self,
         repo_id: Uuid,
         file_path: &str,
@@ -225,7 +270,6 @@ impl SymbolClaimTracker {
                         conflicting_agent: claim.agent_name.clone(),
                         first_touched_at: claim.first_touched_at,
                     });
-                    // Only report the first conflicting session per symbol
                     break;
                 }
             }
@@ -233,11 +277,7 @@ impl SymbolClaimTracker {
         conflicts
     }
 
-    /// Return all conflicts for a given session across ALL file paths.
-    ///
-    /// This checks every tracked file to find symbols where `session_id` has
-    /// a claim AND another session also claims the same symbol.
-    pub fn get_all_conflicts_for_session(
+    async fn get_all_conflicts_for_session(
         &self,
         repo_id: Uuid,
         session_id: Uuid,
@@ -250,14 +290,12 @@ impl SymbolClaimTracker {
             }
             let claims = entry.value();
 
-            // Find symbols claimed by this session
             let my_symbols: Vec<&SymbolClaim> = claims
                 .iter()
                 .filter(|c| c.session_id == session_id)
                 .collect();
 
             for my_claim in &my_symbols {
-                // Check if any OTHER session also claims this symbol
                 for other_claim in claims {
                     if other_claim.session_id != session_id
                         && other_claim.qualified_name == my_claim.qualified_name
@@ -272,7 +310,6 @@ impl SymbolClaimTracker {
                                 first_touched_at: other_claim.first_touched_at,
                             },
                         ));
-                        // Only report the first conflicting session per symbol
                         break;
                     }
                 }
@@ -281,10 +318,7 @@ impl SymbolClaimTracker {
         results
     }
 
-    /// Remove all claims belonging to a session across ALL repos (e.g. on
-    /// disconnect or GC). Returns the released locks so callers can emit
-    /// `symbol.lock.released` events to unblock waiting agents.
-    pub fn clear_session(&self, session_id: Uuid) -> Vec<ReleasedLock> {
+    async fn clear_session(&self, session_id: Uuid) -> Vec<ReleasedLock> {
         let mut released = Vec::new();
         let mut empty_keys = Vec::new();
         for mut entry in self.claims.iter_mut() {
@@ -313,12 +347,6 @@ impl SymbolClaimTracker {
     }
 }
 
-impl Default for SymbolClaimTracker {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -333,128 +361,137 @@ mod tests {
         }
     }
 
-    #[test]
-    fn no_conflict_different_symbols_same_file() {
-        let tracker = SymbolClaimTracker::new();
+    #[tokio::test]
+    async fn no_conflict_different_symbols_same_file() {
+        let tracker = LocalClaimTracker::new();
         let repo = Uuid::new_v4();
         let session_a = Uuid::new_v4();
         let session_b = Uuid::new_v4();
 
-        tracker.record_claim(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-        );
+        tracker
+            .record_claim(
+                repo,
+                "src/lib.rs",
+                make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+            )
+            .await;
 
-        let conflicts = tracker.check_conflicts(
-            repo,
-            "src/lib.rs",
-            session_b,
-            &["fn_b".to_string()],
-        );
+        let conflicts = tracker
+            .check_conflicts(repo, "src/lib.rs", session_b, &["fn_b".to_string()])
+            .await;
         assert!(conflicts.is_empty(), "different symbols should not conflict");
     }
 
-    #[test]
-    fn conflict_same_symbol() {
-        let tracker = SymbolClaimTracker::new();
+    #[tokio::test]
+    async fn conflict_same_symbol() {
+        let tracker = LocalClaimTracker::new();
         let repo = Uuid::new_v4();
         let session_a = Uuid::new_v4();
         let session_b = Uuid::new_v4();
 
-        tracker.record_claim(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-        );
+        tracker
+            .record_claim(
+                repo,
+                "src/lib.rs",
+                make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+            )
+            .await;
 
-        let conflicts = tracker.check_conflicts(
-            repo,
-            "src/lib.rs",
-            session_b,
-            &["fn_a".to_string()],
-        );
+        let conflicts = tracker
+            .check_conflicts(repo, "src/lib.rs", session_b, &["fn_a".to_string()])
+            .await;
         assert_eq!(conflicts.len(), 1);
         assert_eq!(conflicts[0].qualified_name, "fn_a");
         assert_eq!(conflicts[0].conflicting_session, session_a);
         assert_eq!(conflicts[0].conflicting_agent, "agent-1");
     }
 
-    #[test]
-    fn claims_cleared_on_session_destroy() {
-        let tracker = SymbolClaimTracker::new();
+    #[tokio::test]
+    async fn claims_cleared_on_session_destroy() {
+        let tracker = LocalClaimTracker::new();
         let repo = Uuid::new_v4();
         let session_a = Uuid::new_v4();
         let session_b = Uuid::new_v4();
 
-        tracker.record_claim(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-        );
+        tracker
+            .record_claim(
+                repo,
+                "src/lib.rs",
+                make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+            )
+            .await;
 
-        tracker.clear_session(session_a);
+        tracker.clear_session(session_a).await;
 
-        let conflicts = tracker.check_conflicts(
-            repo,
-            "src/lib.rs",
-            session_b,
-            &["fn_a".to_string()],
+        let conflicts = tracker
+            .check_conflicts(repo, "src/lib.rs", session_b, &["fn_a".to_string()])
+            .await;
+        assert!(
+            conflicts.is_empty(),
+            "cleared session should not cause conflicts"
         );
-        assert!(conflicts.is_empty(), "cleared session should not cause conflicts");
     }
 
-    #[test]
-    fn same_session_no_self_conflict() {
-        let tracker = SymbolClaimTracker::new();
+    #[tokio::test]
+    async fn same_session_no_self_conflict() {
+        let tracker = LocalClaimTracker::new();
         let repo = Uuid::new_v4();
         let session_a = Uuid::new_v4();
 
-        tracker.record_claim(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-        );
-        // Re-write same symbol from same session
-        tracker.record_claim(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-        );
+        tracker
+            .record_claim(
+                repo,
+                "src/lib.rs",
+                make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+            )
+            .await;
+        tracker
+            .record_claim(
+                repo,
+                "src/lib.rs",
+                make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+            )
+            .await;
 
-        let conflicts = tracker.check_conflicts(
-            repo,
-            "src/lib.rs",
-            session_a,
-            &["fn_a".to_string()],
+        let conflicts = tracker
+            .check_conflicts(repo, "src/lib.rs", session_a, &["fn_a".to_string()])
+            .await;
+        assert!(
+            conflicts.is_empty(),
+            "same session should not conflict with itself"
         );
-        assert!(conflicts.is_empty(), "same session should not conflict with itself");
     }
 
-    #[test]
-    fn multiple_conflicts() {
-        let tracker = SymbolClaimTracker::new();
+    #[tokio::test]
+    async fn multiple_conflicts() {
+        let tracker = LocalClaimTracker::new();
         let repo = Uuid::new_v4();
         let session_a = Uuid::new_v4();
         let session_b = Uuid::new_v4();
 
-        tracker.record_claim(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-        );
-        tracker.record_claim(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_b", SymbolKind::Function),
-        );
+        tracker
+            .record_claim(
+                repo,
+                "src/lib.rs",
+                make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+            )
+            .await;
+        tracker
+            .record_claim(
+                repo,
+                "src/lib.rs",
+                make_claim(session_a, "agent-1", "fn_b", SymbolKind::Function),
+            )
+            .await;
 
-        let conflicts = tracker.check_conflicts(
-            repo,
-            "src/lib.rs",
-            session_b,
-            &["fn_a".to_string(), "fn_b".to_string()],
-        );
+        let conflicts = tracker
+            .check_conflicts(
+                repo,
+                "src/lib.rs",
+                session_b,
+                &["fn_a".to_string(), "fn_b".to_string()],
+            )
+            .await;
         assert_eq!(conflicts.len(), 2);
 
         let names: Vec<&str> = conflicts.iter().map(|c| c.qualified_name.as_str()).collect();
@@ -462,61 +499,70 @@ mod tests {
         assert!(names.contains(&"fn_b"));
     }
 
-    // ── acquire_lock tests ──
-
-    #[test]
-    fn acquire_lock_unclaimed_succeeds() {
-        let tracker = SymbolClaimTracker::new();
+    #[tokio::test]
+    async fn acquire_lock_unclaimed_succeeds() {
+        let tracker = LocalClaimTracker::new();
         let repo = Uuid::new_v4();
         let session = Uuid::new_v4();
 
-        let result = tracker.acquire_lock(
-            repo,
-            "src/lib.rs",
-            make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
-        );
+        let result = tracker
+            .acquire_lock(
+                repo,
+                "src/lib.rs",
+                make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
+            )
+            .await;
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn acquire_lock_same_session_succeeds() {
-        let tracker = SymbolClaimTracker::new();
+    #[tokio::test]
+    async fn acquire_lock_same_session_succeeds() {
+        let tracker = LocalClaimTracker::new();
         let repo = Uuid::new_v4();
         let session = Uuid::new_v4();
 
-        tracker.acquire_lock(
-            repo,
-            "src/lib.rs",
-            make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
-        ).unwrap();
+        tracker
+            .acquire_lock(
+                repo,
+                "src/lib.rs",
+                make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
+            )
+            .await
+            .unwrap();
 
-        // Same session re-acquiring same symbol should succeed
-        let result = tracker.acquire_lock(
-            repo,
-            "src/lib.rs",
-            make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
-        );
+        let result = tracker
+            .acquire_lock(
+                repo,
+                "src/lib.rs",
+                make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
+            )
+            .await;
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn acquire_lock_cross_session_blocked() {
-        let tracker = SymbolClaimTracker::new();
+    #[tokio::test]
+    async fn acquire_lock_cross_session_blocked() {
+        let tracker = LocalClaimTracker::new();
         let repo = Uuid::new_v4();
         let session_a = Uuid::new_v4();
         let session_b = Uuid::new_v4();
 
-        tracker.acquire_lock(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-        ).unwrap();
+        tracker
+            .acquire_lock(
+                repo,
+                "src/lib.rs",
+                make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+            )
+            .await
+            .unwrap();
 
-        let result = tracker.acquire_lock(
-            repo,
-            "src/lib.rs",
-            make_claim(session_b, "agent-2", "fn_a", SymbolKind::Function),
-        );
+        let result = tracker
+            .acquire_lock(
+                repo,
+                "src/lib.rs",
+                make_claim(session_b, "agent-2", "fn_a", SymbolKind::Function),
+            )
+            .await;
         assert!(result.is_err());
         let locked = result.unwrap_err();
         assert_eq!(locked.qualified_name, "fn_a");
@@ -524,94 +570,109 @@ mod tests {
         assert_eq!(locked.locked_by_agent, "agent-1");
     }
 
-    #[test]
-    fn acquire_lock_different_symbols_same_file() {
-        let tracker = SymbolClaimTracker::new();
+    #[tokio::test]
+    async fn acquire_lock_different_symbols_same_file() {
+        let tracker = LocalClaimTracker::new();
         let repo = Uuid::new_v4();
         let session_a = Uuid::new_v4();
         let session_b = Uuid::new_v4();
 
-        tracker.acquire_lock(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-        ).unwrap();
+        tracker
+            .acquire_lock(
+                repo,
+                "src/lib.rs",
+                make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+            )
+            .await
+            .unwrap();
 
-        // Different symbol in same file — should succeed
-        let result = tracker.acquire_lock(
-            repo,
-            "src/lib.rs",
-            make_claim(session_b, "agent-2", "fn_b", SymbolKind::Function),
-        );
+        let result = tracker
+            .acquire_lock(
+                repo,
+                "src/lib.rs",
+                make_claim(session_b, "agent-2", "fn_b", SymbolKind::Function),
+            )
+            .await;
         assert!(result.is_ok());
     }
 
-    // ── release_lock tests ──
-
-    #[test]
-    fn release_lock_single_symbol() {
-        let tracker = SymbolClaimTracker::new();
+    #[tokio::test]
+    async fn release_lock_single_symbol() {
+        let tracker = LocalClaimTracker::new();
         let repo = Uuid::new_v4();
         let session_a = Uuid::new_v4();
         let session_b = Uuid::new_v4();
 
-        tracker.acquire_lock(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-        ).unwrap();
+        tracker
+            .acquire_lock(
+                repo,
+                "src/lib.rs",
+                make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+            )
+            .await
+            .unwrap();
 
-        // Release the lock
-        tracker.release_lock(repo, "src/lib.rs", session_a, "fn_a");
+        tracker
+            .release_lock(repo, "src/lib.rs", session_a, "fn_a")
+            .await;
 
-        // Now another session should be able to acquire it
-        let result = tracker.acquire_lock(
-            repo,
-            "src/lib.rs",
-            make_claim(session_b, "agent-2", "fn_a", SymbolKind::Function),
-        );
+        let result = tracker
+            .acquire_lock(
+                repo,
+                "src/lib.rs",
+                make_claim(session_b, "agent-2", "fn_a", SymbolKind::Function),
+            )
+            .await;
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn release_lock_cleans_empty_entries() {
-        let tracker = SymbolClaimTracker::new();
+    #[tokio::test]
+    async fn release_lock_cleans_empty_entries() {
+        let tracker = LocalClaimTracker::new();
         let repo = Uuid::new_v4();
         let session = Uuid::new_v4();
 
-        tracker.acquire_lock(
-            repo,
-            "src/lib.rs",
-            make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
-        ).unwrap();
+        tracker
+            .acquire_lock(
+                repo,
+                "src/lib.rs",
+                make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
+            )
+            .await
+            .unwrap();
 
-        tracker.release_lock(repo, "src/lib.rs", session, "fn_a");
+        tracker
+            .release_lock(repo, "src/lib.rs", session, "fn_a")
+            .await;
 
-        // The key should be removed from the map (no empty vecs lingering)
         let key = (repo, "src/lib.rs".to_string());
         assert!(tracker.claims.get(&key).is_none());
     }
 
-    // ── release_locks tests ──
-
-    #[test]
-    fn release_locks_returns_released_entries() {
-        let tracker = SymbolClaimTracker::new();
+    #[tokio::test]
+    async fn release_locks_returns_released_entries() {
+        let tracker = LocalClaimTracker::new();
         let repo = Uuid::new_v4();
         let session = Uuid::new_v4();
 
-        tracker.acquire_lock(
-            repo,
-            "src/lib.rs",
-            make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
-        ).unwrap();
-        tracker.acquire_lock(
-            repo,
-            "src/api.rs",
-            make_claim(session, "agent-1", "handler", SymbolKind::Function),
-        ).unwrap();
+        tracker
+            .acquire_lock(
+                repo,
+                "src/lib.rs",
+                make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
+            )
+            .await
+            .unwrap();
+        tracker
+            .acquire_lock(
+                repo,
+                "src/api.rs",
+                make_claim(session, "agent-1", "handler", SymbolKind::Function),
+            )
+            .await
+            .unwrap();
 
-        let released = tracker.release_locks(repo, session);
+        let released = tracker.release_locks(repo, session).await;
         assert_eq!(released.len(), 2);
 
         let names: Vec<&str> = released.iter().map(|r| r.qualified_name.as_str()).collect();
@@ -619,34 +680,40 @@ mod tests {
         assert!(names.contains(&"handler"));
     }
 
-    #[test]
-    fn release_locks_unblocks_other_session() {
-        let tracker = SymbolClaimTracker::new();
+    #[tokio::test]
+    async fn release_locks_unblocks_other_session() {
+        let tracker = LocalClaimTracker::new();
         let repo = Uuid::new_v4();
         let session_a = Uuid::new_v4();
         let session_b = Uuid::new_v4();
 
-        tracker.acquire_lock(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-        ).unwrap();
+        tracker
+            .acquire_lock(
+                repo,
+                "src/lib.rs",
+                make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+            )
+            .await
+            .unwrap();
 
-        // session_b is blocked
-        assert!(tracker.acquire_lock(
-            repo,
-            "src/lib.rs",
-            make_claim(session_b, "agent-2", "fn_a", SymbolKind::Function),
-        ).is_err());
+        assert!(tracker
+            .acquire_lock(
+                repo,
+                "src/lib.rs",
+                make_claim(session_b, "agent-2", "fn_a", SymbolKind::Function),
+            )
+            .await
+            .is_err());
 
-        // Release session_a
-        tracker.release_locks(repo, session_a);
+        tracker.release_locks(repo, session_a).await;
 
-        // session_b can now acquire
-        assert!(tracker.acquire_lock(
-            repo,
-            "src/lib.rs",
-            make_claim(session_b, "agent-2", "fn_a", SymbolKind::Function),
-        ).is_ok());
+        assert!(tracker
+            .acquire_lock(
+                repo,
+                "src/lib.rs",
+                make_claim(session_b, "agent-2", "fn_a", SymbolKind::Function),
+            )
+            .await
+            .is_ok());
     }
 }

--- a/crates/dk-engine/src/conflict/claim_tracker.rs
+++ b/crates/dk-engine/src/conflict/claim_tracker.rs
@@ -1,17 +1,18 @@
+use chrono::{DateTime, Utc};
 use dashmap::DashMap;
-use std::time::Instant;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use dk_core::SymbolKind;
 
 /// A claim that a particular session has touched a symbol.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SymbolClaim {
     pub session_id: Uuid,
     pub agent_name: String,
     pub qualified_name: String,
     pub kind: SymbolKind,
-    pub first_touched_at: Instant,
+    pub first_touched_at: DateTime<Utc>,
 }
 
 /// Information about a detected conflict: another session already claims
@@ -22,7 +23,7 @@ pub struct ConflictInfo {
     pub kind: SymbolKind,
     pub conflicting_session: Uuid,
     pub conflicting_agent: String,
-    pub first_touched_at: Instant,
+    pub first_touched_at: DateTime<Utc>,
 }
 
 /// Information about a symbol lock held by another session.
@@ -33,7 +34,7 @@ pub struct SymbolLocked {
     pub kind: SymbolKind,
     pub locked_by_session: Uuid,
     pub locked_by_agent: String,
-    pub locked_since: Instant,
+    pub locked_since: DateTime<Utc>,
     pub file_path: String,
 }
 
@@ -328,7 +329,7 @@ mod tests {
             agent_name: agent.to_string(),
             qualified_name: name.to_string(),
             kind,
-            first_touched_at: Instant::now(),
+            first_touched_at: Utc::now(),
         }
     }
 

--- a/crates/dk-engine/src/conflict/mod.rs
+++ b/crates/dk-engine/src/conflict/mod.rs
@@ -3,7 +3,10 @@ mod claim_tracker;
 pub mod payload;
 
 pub use ast_merge::{ast_merge, MergeResult, MergeStatus, SymbolConflict};
-pub use claim_tracker::{AcquireOutcome, ConflictInfo, ReleasedLock, SymbolClaim, SymbolClaimTracker, SymbolLocked};
+pub use claim_tracker::{
+    AcquireOutcome, ClaimTracker, ConflictInfo, LocalClaimTracker, ReleasedLock, SymbolClaim,
+    SymbolLocked,
+};
 pub use payload::{
     build_conflict_block, build_conflict_detail, ConflictBlock, SymbolConflictDetail,
     SymbolVersion,

--- a/crates/dk-engine/src/conflict/mod.rs
+++ b/crates/dk-engine/src/conflict/mod.rs
@@ -1,6 +1,8 @@
 pub mod ast_merge;
 mod claim_tracker;
 pub mod payload;
+#[cfg(feature = "valkey")]
+mod valkey_claim_tracker;
 
 pub use ast_merge::{ast_merge, MergeResult, MergeStatus, SymbolConflict};
 pub use claim_tracker::{
@@ -11,3 +13,5 @@ pub use payload::{
     build_conflict_block, build_conflict_detail, ConflictBlock, SymbolConflictDetail,
     SymbolVersion,
 };
+#[cfg(feature = "valkey")]
+pub use valkey_claim_tracker::ValkeyClaimTracker;

--- a/crates/dk-engine/src/conflict/valkey_claim_tracker.rs
+++ b/crates/dk-engine/src/conflict/valkey_claim_tracker.rs
@@ -40,6 +40,7 @@ if existing then
     local claim = cjson.decode(existing)
     if claim.session_id == ARGV[1] then
         redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[3])
+        redis.call('EXPIRE', KEYS[2], ARGV[3])
         return 'REACQUIRE'
     else
         return existing
@@ -82,10 +83,12 @@ impl ValkeyClaimTracker {
         }
         let repo_id = rest[..36].parse::<Uuid>().ok()?;
         let after_repo = &rest[37..]; // skip the ":"
-        // file_path:qualified_name — split on the LAST ":"
-        let last_colon = after_repo.rfind(':')?;
-        let file_path = after_repo[..last_colon].to_string();
-        let qualified_name = after_repo[last_colon + 1..].to_string();
+        // file_path:qualified_name — split on the FIRST ":"
+        // We use find() not rfind() because qualified names can contain "::"
+        // (e.g., MyStruct::method) but Unix file paths never contain ":".
+        let first_colon = after_repo.find(':')?;
+        let file_path = after_repo[..first_colon].to_string();
+        let qualified_name = after_repo[first_colon + 1..].to_string();
         Some((repo_id, file_path, qualified_name))
     }
 }
@@ -306,32 +309,20 @@ impl ClaimTracker for ValkeyClaimTracker {
         conflicts
     }
 
+    /// Returns empty for ValkeyClaimTracker because Valkey locks are exclusive:
+    /// only one session can hold a given symbol lock at a time. Cross-session
+    /// conflicts are prevented at write time by `acquire_lock`, so there are
+    /// no concurrent claims to surface. This method is only meaningful for
+    /// the non-blocking `record_claim` path used by `LocalClaimTracker`.
     async fn get_all_conflicts_for_session(
         &self,
-        repo_id: Uuid,
-        session_id: Uuid,
+        _repo_id: Uuid,
+        _session_id: Uuid,
     ) -> Vec<(String, ConflictInfo)> {
-        let sess_key = Self::session_set_key(session_id);
-        let prefix = format!("lock:{repo_id}:");
-
-        let mut conn = self.conn.clone();
-
-        let all_keys: Vec<String> = match conn.smembers(&sess_key).await {
-            Ok(keys) => keys,
-            Err(_) => return Vec::new(),
-        };
-
-        let my_keys: Vec<&String> = all_keys.iter().filter(|k| k.starts_with(&prefix)).collect();
-        if my_keys.is_empty() {
-            return Vec::new();
-        }
-
-        // For each of my lock keys, check if another session also holds a
-        // lock on the same symbol. Since Valkey locks are exclusive (only one
-        // session can hold a key), cross-session conflicts in Valkey mode
-        // would only exist if record_claim was used (non-blocking). With
-        // acquire_lock (blocking), conflicts are prevented at write time.
-        // Return empty — the blocking model prevents concurrent claims.
+        // Valkey locks are exclusive — acquire_lock rejects cross-session
+        // claims at write time, so no concurrent claims can accumulate.
+        // Only the non-blocking record_claim path (LocalClaimTracker)
+        // can produce conflicts surfaced by this method.
         Vec::new()
     }
 

--- a/crates/dk-engine/src/conflict/valkey_claim_tracker.rs
+++ b/crates/dk-engine/src/conflict/valkey_claim_tracker.rs
@@ -131,6 +131,7 @@ impl ClaimTracker for ValkeyClaimTracker {
             .cmd("SET")
             .arg(&lock_key)
             .arg(&json)
+            .arg("NX")
             .arg("EX")
             .arg(TTL_SECS)
             .cmd("SADD")

--- a/crates/dk-engine/src/conflict/valkey_claim_tracker.rs
+++ b/crates/dk-engine/src/conflict/valkey_claim_tracker.rs
@@ -40,6 +40,7 @@ if existing then
     local claim = cjson.decode(existing)
     if claim.session_id == ARGV[1] then
         redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[3])
+        redis.call('SADD', KEYS[2], KEYS[1])
         redis.call('EXPIRE', KEYS[2], ARGV[3])
         return 'REACQUIRE'
     else

--- a/crates/dk-engine/src/conflict/valkey_claim_tracker.rs
+++ b/crates/dk-engine/src/conflict/valkey_claim_tracker.rs
@@ -1,0 +1,417 @@
+//! Valkey/Redis-backed [`ClaimTracker`] implementation.
+//!
+//! Available only when the `valkey` cargo feature is enabled.
+//!
+//! ## Key schema
+//!
+//! | Pattern | Value |
+//! |---------|-------|
+//! | `lock:{repo_id}:{file_path}:{qualified_name}` | JSON `SymbolClaim` |
+//! | `sess:{session_id}` | Redis SET of lock key strings |
+//!
+//! All keys have a 2-hour TTL as a safety net for crashed sessions.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use redis::AsyncCommands;
+use uuid::Uuid;
+
+use super::claim_tracker::{
+    AcquireOutcome, ClaimTracker, ConflictInfo, ReleasedLock, SymbolClaim, SymbolLocked,
+};
+
+const TTL_SECS: u64 = 7200; // 2 hours
+
+/// Lua script for atomic acquire_lock.
+///
+/// KEYS[1] = lock key
+/// KEYS[2] = session set key
+/// ARGV[1] = session_id (string)
+/// ARGV[2] = claim JSON
+/// ARGV[3] = TTL seconds
+///
+/// Returns:
+///   `"FRESH"`     — lock acquired for the first time
+///   `"REACQUIRE"` — same session already holds it (updated)
+///   JSON string   — existing claim from a different session (blocked)
+const ACQUIRE_SCRIPT: &str = r#"
+local existing = redis.call('GET', KEYS[1])
+if existing then
+    local claim = cjson.decode(existing)
+    if claim.session_id == ARGV[1] then
+        redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[3])
+        return 'REACQUIRE'
+    else
+        return existing
+    end
+end
+redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[3])
+redis.call('SADD', KEYS[2], KEYS[1])
+redis.call('EXPIRE', KEYS[2], ARGV[3])
+return 'FRESH'
+"#;
+
+/// Valkey/Redis-backed claim tracker for cross-pod symbol locking.
+pub struct ValkeyClaimTracker {
+    conn: redis::aio::ConnectionManager,
+}
+
+impl ValkeyClaimTracker {
+    /// Connect to a Valkey/Redis instance.
+    pub async fn new(url: &str) -> Result<Self, redis::RedisError> {
+        let client = redis::Client::open(url)?;
+        let conn = redis::aio::ConnectionManager::new(client).await?;
+        Ok(Self { conn })
+    }
+
+    fn lock_key(repo_id: Uuid, file_path: &str, qualified_name: &str) -> String {
+        format!("lock:{repo_id}:{file_path}:{qualified_name}")
+    }
+
+    fn session_set_key(session_id: Uuid) -> String {
+        format!("sess:{session_id}")
+    }
+
+    /// Parse a lock key back into (repo_id, file_path, qualified_name).
+    /// Key format: `lock:{repo_id}:{file_path}:{qualified_name}`
+    fn parse_lock_key(key: &str) -> Option<(Uuid, String, String)> {
+        let rest = key.strip_prefix("lock:")?;
+        // repo_id is always 36 chars (UUID)
+        if rest.len() < 38 {
+            return None;
+        }
+        let repo_id = rest[..36].parse::<Uuid>().ok()?;
+        let after_repo = &rest[37..]; // skip the ":"
+        // file_path:qualified_name — split on the LAST ":"
+        let last_colon = after_repo.rfind(':')?;
+        let file_path = after_repo[..last_colon].to_string();
+        let qualified_name = after_repo[last_colon + 1..].to_string();
+        Some((repo_id, file_path, qualified_name))
+    }
+}
+
+#[async_trait]
+impl ClaimTracker for ValkeyClaimTracker {
+    async fn record_claim(&self, repo_id: Uuid, file_path: &str, claim: SymbolClaim) {
+        let lock_key = Self::lock_key(repo_id, file_path, &claim.qualified_name);
+        let sess_key = Self::session_set_key(claim.session_id);
+        let json = match serde_json::to_string(&claim) {
+            Ok(j) => j,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to serialize claim");
+                return;
+            }
+        };
+
+        let mut conn = self.conn.clone();
+        let _: Result<(), _> = redis::pipe()
+            .cmd("SET")
+            .arg(&lock_key)
+            .arg(&json)
+            .arg("EX")
+            .arg(TTL_SECS)
+            .cmd("SADD")
+            .arg(&sess_key)
+            .arg(&lock_key)
+            .cmd("EXPIRE")
+            .arg(&sess_key)
+            .arg(TTL_SECS)
+            .query_async(&mut conn)
+            .await;
+    }
+
+    async fn acquire_lock(
+        &self,
+        repo_id: Uuid,
+        file_path: &str,
+        claim: SymbolClaim,
+    ) -> Result<AcquireOutcome, SymbolLocked> {
+        let lock_key = Self::lock_key(repo_id, file_path, &claim.qualified_name);
+        let sess_key = Self::session_set_key(claim.session_id);
+        let claim_json = serde_json::to_string(&claim).map_err(|e| SymbolLocked {
+            qualified_name: claim.qualified_name.clone(),
+            kind: claim.kind.clone(),
+            locked_by_session: claim.session_id,
+            locked_by_agent: format!("serialization error: {e}"),
+            locked_since: Utc::now(),
+            file_path: file_path.to_string(),
+        })?;
+
+        let mut conn = self.conn.clone();
+        let result: String = redis::Script::new(ACQUIRE_SCRIPT)
+            .key(&lock_key)
+            .key(&sess_key)
+            .arg(claim.session_id.to_string())
+            .arg(&claim_json)
+            .arg(TTL_SECS)
+            .invoke_async(&mut conn)
+            .await
+            .map_err(|e| SymbolLocked {
+                qualified_name: claim.qualified_name.clone(),
+                kind: claim.kind.clone(),
+                locked_by_session: Uuid::nil(),
+                locked_by_agent: format!("Valkey error: {e}"),
+                locked_since: Utc::now(),
+                file_path: file_path.to_string(),
+            })?;
+
+        match result.as_str() {
+            "FRESH" => Ok(AcquireOutcome::Fresh),
+            "REACQUIRE" => Ok(AcquireOutcome::ReAcquired),
+            json_str => {
+                // Another session holds the lock — parse their claim
+                let holder: SymbolClaim =
+                    serde_json::from_str(json_str).map_err(|e| SymbolLocked {
+                        qualified_name: claim.qualified_name.clone(),
+                        kind: claim.kind.clone(),
+                        locked_by_session: Uuid::nil(),
+                        locked_by_agent: format!("parse error: {e}"),
+                        locked_since: Utc::now(),
+                        file_path: file_path.to_string(),
+                    })?;
+                Err(SymbolLocked {
+                    qualified_name: claim.qualified_name,
+                    kind: holder.kind,
+                    locked_by_session: holder.session_id,
+                    locked_by_agent: holder.agent_name,
+                    locked_since: holder.first_touched_at,
+                    file_path: file_path.to_string(),
+                })
+            }
+        }
+    }
+
+    async fn release_lock(
+        &self,
+        repo_id: Uuid,
+        file_path: &str,
+        session_id: Uuid,
+        qualified_name: &str,
+    ) {
+        let lock_key = Self::lock_key(repo_id, file_path, qualified_name);
+        let sess_key = Self::session_set_key(session_id);
+
+        let mut conn = self.conn.clone();
+        let _: Result<(), _> = redis::pipe()
+            .del(&lock_key)
+            .cmd("SREM")
+            .arg(&sess_key)
+            .arg(&lock_key)
+            .query_async(&mut conn)
+            .await;
+    }
+
+    async fn release_locks(&self, repo_id: Uuid, session_id: Uuid) -> Vec<ReleasedLock> {
+        let sess_key = Self::session_set_key(session_id);
+        let prefix = format!("lock:{repo_id}:");
+
+        let mut conn = self.conn.clone();
+
+        // Get all lock keys for this session
+        let all_keys: Vec<String> = match conn.smembers(&sess_key).await {
+            Ok(keys) => keys,
+            Err(_) => return Vec::new(),
+        };
+
+        // Filter to keys belonging to this repo
+        let repo_keys: Vec<&String> = all_keys.iter().filter(|k| k.starts_with(&prefix)).collect();
+        if repo_keys.is_empty() {
+            return Vec::new();
+        }
+
+        // MGET to read claim data before deleting
+        let values: Vec<Option<String>> = match redis::cmd("MGET")
+            .arg(repo_keys.iter().map(|k| k.as_str()).collect::<Vec<_>>())
+            .query_async(&mut conn)
+            .await
+        {
+            Ok(v) => v,
+            Err(_) => return Vec::new(),
+        };
+
+        // Build released list from stored claims
+        let mut released = Vec::new();
+        let mut pipe = redis::pipe();
+
+        for (key, value) in repo_keys.iter().zip(values.iter()) {
+            if let Some(json) = value {
+                if let Ok(claim) = serde_json::from_str::<SymbolClaim>(json) {
+                    if let Some((_, file_path, _)) = Self::parse_lock_key(key) {
+                        released.push(ReleasedLock {
+                            file_path,
+                            qualified_name: claim.qualified_name,
+                            kind: claim.kind,
+                            agent_name: claim.agent_name,
+                        });
+                    }
+                }
+            }
+            pipe.del(*key);
+            pipe.cmd("SREM").arg(&sess_key).arg(*key);
+        }
+
+        // Execute deletes + remove from session set
+        let _: Result<(), _> = pipe.query_async(&mut conn).await;
+
+        // If we released all keys for this session, clean up the set
+        if repo_keys.len() == all_keys.len() {
+            let _: Result<(), _> = conn.del(&sess_key).await;
+        }
+
+        released
+    }
+
+    async fn check_conflicts(
+        &self,
+        repo_id: Uuid,
+        file_path: &str,
+        session_id: Uuid,
+        qualified_names: &[String],
+    ) -> Vec<ConflictInfo> {
+        if qualified_names.is_empty() {
+            return Vec::new();
+        }
+
+        let keys: Vec<String> = qualified_names
+            .iter()
+            .map(|name| Self::lock_key(repo_id, file_path, name))
+            .collect();
+
+        let mut conn = self.conn.clone();
+        let values: Vec<Option<String>> = match redis::cmd("MGET")
+            .arg(keys.iter().map(|k| k.as_str()).collect::<Vec<_>>())
+            .query_async(&mut conn)
+            .await
+        {
+            Ok(v) => v,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut conflicts = Vec::new();
+        for (name, value) in qualified_names.iter().zip(values.iter()) {
+            if let Some(json) = value {
+                if let Ok(claim) = serde_json::from_str::<SymbolClaim>(json) {
+                    if claim.session_id != session_id {
+                        conflicts.push(ConflictInfo {
+                            qualified_name: name.clone(),
+                            kind: claim.kind,
+                            conflicting_session: claim.session_id,
+                            conflicting_agent: claim.agent_name,
+                            first_touched_at: claim.first_touched_at,
+                        });
+                    }
+                }
+            }
+        }
+        conflicts
+    }
+
+    async fn get_all_conflicts_for_session(
+        &self,
+        repo_id: Uuid,
+        session_id: Uuid,
+    ) -> Vec<(String, ConflictInfo)> {
+        let sess_key = Self::session_set_key(session_id);
+        let prefix = format!("lock:{repo_id}:");
+
+        let mut conn = self.conn.clone();
+
+        let all_keys: Vec<String> = match conn.smembers(&sess_key).await {
+            Ok(keys) => keys,
+            Err(_) => return Vec::new(),
+        };
+
+        let my_keys: Vec<&String> = all_keys.iter().filter(|k| k.starts_with(&prefix)).collect();
+        if my_keys.is_empty() {
+            return Vec::new();
+        }
+
+        // For each of my lock keys, check if another session also holds a
+        // lock on the same symbol. Since Valkey locks are exclusive (only one
+        // session can hold a key), cross-session conflicts in Valkey mode
+        // would only exist if record_claim was used (non-blocking). With
+        // acquire_lock (blocking), conflicts are prevented at write time.
+        // Return empty — the blocking model prevents concurrent claims.
+        Vec::new()
+    }
+
+    async fn clear_session(&self, session_id: Uuid) -> Vec<ReleasedLock> {
+        let sess_key = Self::session_set_key(session_id);
+
+        let mut conn = self.conn.clone();
+
+        let all_keys: Vec<String> = match conn.smembers(&sess_key).await {
+            Ok(keys) => keys,
+            Err(_) => return Vec::new(),
+        };
+
+        if all_keys.is_empty() {
+            return Vec::new();
+        }
+
+        // MGET all values before deleting
+        let values: Vec<Option<String>> = match redis::cmd("MGET")
+            .arg(all_keys.iter().map(|k| k.as_str()).collect::<Vec<_>>())
+            .query_async(&mut conn)
+            .await
+        {
+            Ok(v) => v,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut released = Vec::new();
+        let mut pipe = redis::pipe();
+
+        for (key, value) in all_keys.iter().zip(values.iter()) {
+            if let Some(json) = value {
+                if let Ok(claim) = serde_json::from_str::<SymbolClaim>(json) {
+                    if let Some((_, file_path, _)) = Self::parse_lock_key(key) {
+                        released.push(ReleasedLock {
+                            file_path,
+                            qualified_name: claim.qualified_name,
+                            kind: claim.kind,
+                            agent_name: claim.agent_name,
+                        });
+                    }
+                }
+            }
+            pipe.del(key);
+        }
+        pipe.del(&sess_key);
+
+        let _: Result<(), _> = pipe.query_async(&mut conn).await;
+
+        released
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_lock_key_valid() {
+        let repo = Uuid::new_v4();
+        let key = format!("lock:{repo}:src/lib.rs:fn_main");
+        let (r, f, q) = ValkeyClaimTracker::parse_lock_key(&key).unwrap();
+        assert_eq!(r, repo);
+        assert_eq!(f, "src/lib.rs");
+        assert_eq!(q, "fn_main");
+    }
+
+    #[test]
+    fn parse_lock_key_nested_path() {
+        let repo = Uuid::new_v4();
+        let key = format!("lock:{repo}:src/api/v2/handler.rs:MyStruct::method");
+        let (r, f, q) = ValkeyClaimTracker::parse_lock_key(&key).unwrap();
+        assert_eq!(r, repo);
+        assert_eq!(f, "src/api/v2/handler.rs");
+        assert_eq!(q, "MyStruct::method");
+    }
+
+    #[test]
+    fn parse_lock_key_invalid() {
+        assert!(ValkeyClaimTracker::parse_lock_key("invalid").is_none());
+        assert!(ValkeyClaimTracker::parse_lock_key("lock:").is_none());
+    }
+}

--- a/crates/dk-engine/src/conflict/valkey_claim_tracker.rs
+++ b/crates/dk-engine/src/conflict/valkey_claim_tracker.rs
@@ -237,19 +237,30 @@ impl ClaimTracker for ValkeyClaimTracker {
         let mut pipe = redis::pipe();
 
         for (key, value) in repo_keys.iter().zip(values.iter()) {
-            if let Some(json) = value {
-                if let Ok(claim) = serde_json::from_str::<SymbolClaim>(json) {
-                    if let Some((_, file_path, _)) = Self::parse_lock_key(key) {
-                        released.push(ReleasedLock {
-                            file_path,
-                            qualified_name: claim.qualified_name,
-                            kind: claim.kind,
-                            agent_name: claim.agent_name,
-                        });
+            // Guard: only DEL if the stored claim still belongs to this session.
+            // A stale session-set entry may point to a lock now owned by another
+            // session (if the original lock expired and was re-acquired).
+            let owned = value
+                .as_deref()
+                .and_then(|json| serde_json::from_str::<SymbolClaim>(json).ok())
+                .map_or(false, |c| c.session_id == session_id);
+
+            if owned {
+                if let Some(json) = value {
+                    if let Ok(claim) = serde_json::from_str::<SymbolClaim>(json) {
+                        if let Some((_, file_path, _)) = Self::parse_lock_key(key) {
+                            released.push(ReleasedLock {
+                                file_path,
+                                qualified_name: claim.qualified_name,
+                                kind: claim.kind,
+                                agent_name: claim.agent_name,
+                            });
+                        }
                     }
                 }
+                pipe.del(*key);
             }
-            pipe.del(*key);
+            // Always remove the stale session-set reference
             pipe.cmd("SREM").arg(&sess_key).arg(*key);
         }
 
@@ -354,19 +365,27 @@ impl ClaimTracker for ValkeyClaimTracker {
         let mut pipe = redis::pipe();
 
         for (key, value) in all_keys.iter().zip(values.iter()) {
-            if let Some(json) = value {
-                if let Ok(claim) = serde_json::from_str::<SymbolClaim>(json) {
-                    if let Some((_, file_path, _)) = Self::parse_lock_key(key) {
-                        released.push(ReleasedLock {
-                            file_path,
-                            qualified_name: claim.qualified_name,
-                            kind: claim.kind,
-                            agent_name: claim.agent_name,
-                        });
+            // Guard: only DEL if the stored claim still belongs to this session.
+            let owned = value
+                .as_deref()
+                .and_then(|json| serde_json::from_str::<SymbolClaim>(json).ok())
+                .map_or(false, |c| c.session_id == session_id);
+
+            if owned {
+                if let Some(json) = value {
+                    if let Ok(claim) = serde_json::from_str::<SymbolClaim>(json) {
+                        if let Some((_, file_path, _)) = Self::parse_lock_key(key) {
+                            released.push(ReleasedLock {
+                                file_path,
+                                qualified_name: claim.qualified_name,
+                                kind: claim.kind,
+                                agent_name: claim.agent_name,
+                            });
+                        }
                     }
                 }
+                pipe.del(key);
             }
-            pipe.del(key);
         }
         pipe.del(&sess_key);
 

--- a/crates/dk-engine/src/conflict/valkey_claim_tracker.rs
+++ b/crates/dk-engine/src/conflict/valkey_claim_tracker.rs
@@ -53,6 +53,25 @@ redis.call('EXPIRE', KEYS[2], ARGV[3])
 return 'FRESH'
 "#;
 
+/// Lua script for atomic release_lock with ownership guard.
+///
+/// KEYS[1] = lock key
+/// KEYS[2] = session set key
+/// ARGV[1] = session_id (string)
+///
+/// Only deletes the lock if the stored claim's session_id matches.
+/// Always removes the key from the session set (cleans stale references).
+const RELEASE_SCRIPT: &str = r#"
+local existing = redis.call('GET', KEYS[1])
+if existing then
+    local claim = cjson.decode(existing)
+    if claim.session_id == ARGV[1] then
+        redis.call('DEL', KEYS[1])
+    end
+end
+redis.call('SREM', KEYS[2], KEYS[1])
+"#;
+
 /// Valkey/Redis-backed claim tracker for cross-pod symbol locking.
 pub struct ValkeyClaimTracker {
     conn: redis::aio::ConnectionManager,
@@ -196,12 +215,14 @@ impl ClaimTracker for ValkeyClaimTracker {
         let sess_key = Self::session_set_key(session_id);
 
         let mut conn = self.conn.clone();
-        let _: Result<(), _> = redis::pipe()
-            .del(&lock_key)
-            .cmd("SREM")
-            .arg(&sess_key)
-            .arg(&lock_key)
-            .query_async(&mut conn)
+        // Use atomic Lua script to only DEL if the stored claim belongs to
+        // this session. Prevents deleting another session's lock if the
+        // original expired and was re-acquired between acquisition and rollback.
+        let _: Result<(), _> = redis::Script::new(RELEASE_SCRIPT)
+            .key(&lock_key)
+            .key(&sess_key)
+            .arg(session_id.to_string())
+            .invoke_async(&mut conn)
             .await;
     }
 

--- a/crates/dk-engine/tests/integration/conflict_claim_test.rs
+++ b/crates/dk-engine/tests/integration/conflict_claim_test.rs
@@ -1,6 +1,17 @@
+//! Integration tests for the [`ClaimTracker`] trait.
+//!
+//! These tests exercise the `acquire_lock` / `release_lock` exclusive-locking
+//! semantics through the trait interface, complementing the `record_claim` /
+//! `check_conflicts` unit tests in `claim_tracker.rs`.
+//!
+//! We use `LocalClaimTracker` here because it needs no external services.
+//! Valkey-specific tests (Lua script atomicity, TTL behaviour, session-index
+//! cleanup) should be added behind `#[cfg(feature = "valkey")]` with a live
+//! Valkey instance (e.g. via `testcontainers`).
+
 use chrono::Utc;
 use dk_core::SymbolKind;
-use dk_engine::conflict::{LocalClaimTracker, SymbolClaim};
+use dk_engine::conflict::{AcquireOutcome, ClaimTracker, LocalClaimTracker, SymbolClaim};
 use uuid::Uuid;
 
 fn make_claim(session_id: Uuid, agent: &str, name: &str, kind: SymbolKind) -> SymbolClaim {
@@ -13,140 +24,245 @@ fn make_claim(session_id: Uuid, agent: &str, name: &str, kind: SymbolKind) -> Sy
     }
 }
 
+/// Helper that exercises `acquire_lock` through the trait object, ensuring
+/// the tests validate the trait contract rather than a concrete type.
+fn tracker() -> Box<dyn ClaimTracker> {
+    Box::new(LocalClaimTracker::new())
+}
+
 #[tokio::test]
-async fn test_no_conflict_different_symbols_same_file() {
-    let tracker = LocalClaimTracker::new();
+async fn acquire_fresh_lock_returns_fresh() {
+    let t = tracker();
+    let repo = Uuid::new_v4();
+    let session = Uuid::new_v4();
+
+    let outcome = t
+        .acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session, "agent-1", "fn_main", SymbolKind::Function),
+        )
+        .await
+        .expect("fresh lock should succeed");
+    assert_eq!(outcome, AcquireOutcome::Fresh);
+}
+
+#[tokio::test]
+async fn reacquire_same_session_returns_reacquired() {
+    let t = tracker();
+    let repo = Uuid::new_v4();
+    let session = Uuid::new_v4();
+
+    t.acquire_lock(
+        repo,
+        "src/lib.rs",
+        make_claim(session, "agent-1", "fn_main", SymbolKind::Function),
+    )
+    .await
+    .unwrap();
+
+    let outcome = t
+        .acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session, "agent-1", "fn_main", SymbolKind::Function),
+        )
+        .await
+        .expect("same session reacquire should succeed");
+    assert_eq!(outcome, AcquireOutcome::ReAcquired);
+}
+
+#[tokio::test]
+async fn cross_session_acquire_is_blocked() {
+    let t = tracker();
     let repo = Uuid::new_v4();
     let session_a = Uuid::new_v4();
     let session_b = Uuid::new_v4();
 
-    tracker
-        .record_claim(
+    t.acquire_lock(
+        repo,
+        "src/lib.rs",
+        make_claim(session_a, "agent-1", "fn_main", SymbolKind::Function),
+    )
+    .await
+    .unwrap();
+
+    let err = t
+        .acquire_lock(
             repo,
             "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+            make_claim(session_b, "agent-2", "fn_main", SymbolKind::Function),
         )
-        .await;
+        .await
+        .expect_err("cross-session acquire should be blocked");
 
-    let conflicts = tracker
-        .check_conflicts(repo, "src/lib.rs", session_b, &["fn_b".to_string()])
-        .await;
-    assert!(conflicts.is_empty(), "different symbols should not conflict");
+    assert_eq!(err.qualified_name, "fn_main");
+    assert_eq!(err.locked_by_session, session_a);
+    assert_eq!(err.locked_by_agent, "agent-1");
 }
 
 #[tokio::test]
-async fn test_conflict_same_symbol() {
-    let tracker = LocalClaimTracker::new();
+async fn release_lock_unblocks_other_session() {
+    let t = tracker();
     let repo = Uuid::new_v4();
     let session_a = Uuid::new_v4();
     let session_b = Uuid::new_v4();
 
-    tracker
-        .record_claim(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-        )
+    t.acquire_lock(
+        repo,
+        "src/lib.rs",
+        make_claim(session_a, "agent-1", "fn_main", SymbolKind::Function),
+    )
+    .await
+    .unwrap();
+
+    // Release session A's lock
+    t.release_lock(repo, "src/lib.rs", session_a, "fn_main")
         .await;
 
-    let conflicts = tracker
-        .check_conflicts(repo, "src/lib.rs", session_b, &["fn_a".to_string()])
-        .await;
-    assert_eq!(conflicts.len(), 1);
-    assert_eq!(conflicts[0].qualified_name, "fn_a");
-    assert_eq!(conflicts[0].conflicting_session, session_a);
-    assert_eq!(conflicts[0].conflicting_agent, "agent-1");
+    // Session B should now succeed
+    let outcome = t
+        .acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session_b, "agent-2", "fn_main", SymbolKind::Function),
+        )
+        .await
+        .expect("should succeed after release");
+    assert_eq!(outcome, AcquireOutcome::Fresh);
 }
 
 #[tokio::test]
-async fn test_claims_cleared_on_session_destroy() {
-    let tracker = LocalClaimTracker::new();
+async fn release_locks_returns_all_released_and_unblocks() {
+    let t = tracker();
     let repo = Uuid::new_v4();
     let session_a = Uuid::new_v4();
     let session_b = Uuid::new_v4();
 
-    tracker
-        .record_claim(
+    // Session A locks two symbols across two files
+    t.acquire_lock(
+        repo,
+        "src/lib.rs",
+        make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+    )
+    .await
+    .unwrap();
+    t.acquire_lock(
+        repo,
+        "src/api.rs",
+        make_claim(session_a, "agent-1", "handler", SymbolKind::Function),
+    )
+    .await
+    .unwrap();
+
+    // Session B is blocked on fn_a
+    assert!(t
+        .acquire_lock(
             repo,
             "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+            make_claim(session_b, "agent-2", "fn_a", SymbolKind::Function),
         )
-        .await;
+        .await
+        .is_err());
 
-    tracker.clear_session(session_a).await;
+    // Release all of session A's locks
+    let released = t.release_locks(repo, session_a).await;
+    assert_eq!(released.len(), 2);
 
-    let conflicts = tracker
-        .check_conflicts(repo, "src/lib.rs", session_b, &["fn_a".to_string()])
-        .await;
-    assert!(
-        conflicts.is_empty(),
-        "cleared session should not cause conflicts"
-    );
-}
-
-#[tokio::test]
-async fn test_same_session_no_self_conflict() {
-    let tracker = LocalClaimTracker::new();
-    let repo = Uuid::new_v4();
-    let session_a = Uuid::new_v4();
-
-    tracker
-        .record_claim(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-        )
-        .await;
-    tracker
-        .record_claim(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-        )
-        .await;
-
-    let conflicts = tracker
-        .check_conflicts(repo, "src/lib.rs", session_a, &["fn_a".to_string()])
-        .await;
-    assert!(
-        conflicts.is_empty(),
-        "same session should not conflict with itself"
-    );
-}
-
-#[tokio::test]
-async fn test_multiple_conflicts() {
-    let tracker = LocalClaimTracker::new();
-    let repo = Uuid::new_v4();
-    let session_a = Uuid::new_v4();
-    let session_b = Uuid::new_v4();
-
-    tracker
-        .record_claim(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-        )
-        .await;
-    tracker
-        .record_claim(
-            repo,
-            "src/lib.rs",
-            make_claim(session_a, "agent-1", "fn_b", SymbolKind::Function),
-        )
-        .await;
-
-    let conflicts = tracker
-        .check_conflicts(
-            repo,
-            "src/lib.rs",
-            session_b,
-            &["fn_a".to_string(), "fn_b".to_string()],
-        )
-        .await;
-    assert_eq!(conflicts.len(), 2);
-
-    let names: Vec<&str> = conflicts.iter().map(|c| c.qualified_name.as_str()).collect();
+    let names: Vec<&str> = released.iter().map(|r| r.qualified_name.as_str()).collect();
     assert!(names.contains(&"fn_a"));
-    assert!(names.contains(&"fn_b"));
+    assert!(names.contains(&"handler"));
+
+    // Session B should now succeed
+    assert!(t
+        .acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session_b, "agent-2", "fn_a", SymbolKind::Function),
+        )
+        .await
+        .is_ok());
+}
+
+#[tokio::test]
+async fn clear_session_releases_all_repos() {
+    let t = tracker();
+    let repo_1 = Uuid::new_v4();
+    let repo_2 = Uuid::new_v4();
+    let session = Uuid::new_v4();
+    let other = Uuid::new_v4();
+
+    t.acquire_lock(
+        repo_1,
+        "src/lib.rs",
+        make_claim(session, "agent-1", "fn_a", SymbolKind::Function),
+    )
+    .await
+    .unwrap();
+    t.acquire_lock(
+        repo_2,
+        "src/main.rs",
+        make_claim(session, "agent-1", "main", SymbolKind::Function),
+    )
+    .await
+    .unwrap();
+
+    // Both are blocked for other session
+    assert!(t
+        .acquire_lock(
+            repo_1,
+            "src/lib.rs",
+            make_claim(other, "agent-2", "fn_a", SymbolKind::Function),
+        )
+        .await
+        .is_err());
+
+    // Clear entire session
+    let released = t.clear_session(session).await;
+    assert_eq!(released.len(), 2);
+
+    // Both repos should now be unblocked
+    assert!(t
+        .acquire_lock(
+            repo_1,
+            "src/lib.rs",
+            make_claim(other, "agent-2", "fn_a", SymbolKind::Function),
+        )
+        .await
+        .is_ok());
+    assert!(t
+        .acquire_lock(
+            repo_2,
+            "src/main.rs",
+            make_claim(other, "agent-2", "main", SymbolKind::Function),
+        )
+        .await
+        .is_ok());
+}
+
+#[tokio::test]
+async fn different_symbols_same_file_no_conflict() {
+    let t = tracker();
+    let repo = Uuid::new_v4();
+    let session_a = Uuid::new_v4();
+    let session_b = Uuid::new_v4();
+
+    t.acquire_lock(
+        repo,
+        "src/lib.rs",
+        make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+    )
+    .await
+    .unwrap();
+
+    // Different symbol in same file should succeed
+    let outcome = t
+        .acquire_lock(
+            repo,
+            "src/lib.rs",
+            make_claim(session_b, "agent-2", "fn_b", SymbolKind::Function),
+        )
+        .await
+        .expect("different symbols should not conflict");
+    assert_eq!(outcome, AcquireOutcome::Fresh);
 }

--- a/crates/dk-engine/tests/integration/conflict_claim_test.rs
+++ b/crates/dk-engine/tests/integration/conflict_claim_test.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use dk_core::SymbolKind;
-use dk_engine::conflict::{SymbolClaim, SymbolClaimTracker};
+use dk_engine::conflict::{LocalClaimTracker, SymbolClaim};
 use uuid::Uuid;
 
 fn make_claim(session_id: Uuid, agent: &str, name: &str, kind: SymbolKind) -> SymbolClaim {
@@ -13,118 +13,137 @@ fn make_claim(session_id: Uuid, agent: &str, name: &str, kind: SymbolKind) -> Sy
     }
 }
 
-#[test]
-fn test_no_conflict_different_symbols_same_file() {
-    let tracker = SymbolClaimTracker::new();
+#[tokio::test]
+async fn test_no_conflict_different_symbols_same_file() {
+    let tracker = LocalClaimTracker::new();
     let repo = Uuid::new_v4();
     let session_a = Uuid::new_v4();
     let session_b = Uuid::new_v4();
 
-    tracker.record_claim(
-        repo,
-        "src/lib.rs",
-        make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-    );
+    tracker
+        .record_claim(
+            repo,
+            "src/lib.rs",
+            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+        )
+        .await;
 
-    let conflicts =
-        tracker.check_conflicts(repo, "src/lib.rs", session_b, &["fn_b".to_string()]);
+    let conflicts = tracker
+        .check_conflicts(repo, "src/lib.rs", session_b, &["fn_b".to_string()])
+        .await;
     assert!(conflicts.is_empty(), "different symbols should not conflict");
 }
 
-#[test]
-fn test_conflict_same_symbol() {
-    let tracker = SymbolClaimTracker::new();
+#[tokio::test]
+async fn test_conflict_same_symbol() {
+    let tracker = LocalClaimTracker::new();
     let repo = Uuid::new_v4();
     let session_a = Uuid::new_v4();
     let session_b = Uuid::new_v4();
 
-    tracker.record_claim(
-        repo,
-        "src/lib.rs",
-        make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-    );
+    tracker
+        .record_claim(
+            repo,
+            "src/lib.rs",
+            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+        )
+        .await;
 
-    let conflicts =
-        tracker.check_conflicts(repo, "src/lib.rs", session_b, &["fn_a".to_string()]);
+    let conflicts = tracker
+        .check_conflicts(repo, "src/lib.rs", session_b, &["fn_a".to_string()])
+        .await;
     assert_eq!(conflicts.len(), 1);
     assert_eq!(conflicts[0].qualified_name, "fn_a");
     assert_eq!(conflicts[0].conflicting_session, session_a);
     assert_eq!(conflicts[0].conflicting_agent, "agent-1");
 }
 
-#[test]
-fn test_claims_cleared_on_session_destroy() {
-    let tracker = SymbolClaimTracker::new();
+#[tokio::test]
+async fn test_claims_cleared_on_session_destroy() {
+    let tracker = LocalClaimTracker::new();
     let repo = Uuid::new_v4();
     let session_a = Uuid::new_v4();
     let session_b = Uuid::new_v4();
 
-    tracker.record_claim(
-        repo,
-        "src/lib.rs",
-        make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-    );
+    tracker
+        .record_claim(
+            repo,
+            "src/lib.rs",
+            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+        )
+        .await;
 
-    tracker.clear_session(session_a);
+    tracker.clear_session(session_a).await;
 
-    let conflicts =
-        tracker.check_conflicts(repo, "src/lib.rs", session_b, &["fn_a".to_string()]);
+    let conflicts = tracker
+        .check_conflicts(repo, "src/lib.rs", session_b, &["fn_a".to_string()])
+        .await;
     assert!(
         conflicts.is_empty(),
         "cleared session should not cause conflicts"
     );
 }
 
-#[test]
-fn test_same_session_no_self_conflict() {
-    let tracker = SymbolClaimTracker::new();
+#[tokio::test]
+async fn test_same_session_no_self_conflict() {
+    let tracker = LocalClaimTracker::new();
     let repo = Uuid::new_v4();
     let session_a = Uuid::new_v4();
 
-    tracker.record_claim(
-        repo,
-        "src/lib.rs",
-        make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-    );
-    // Re-write same symbol from same session
-    tracker.record_claim(
-        repo,
-        "src/lib.rs",
-        make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-    );
+    tracker
+        .record_claim(
+            repo,
+            "src/lib.rs",
+            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+        )
+        .await;
+    tracker
+        .record_claim(
+            repo,
+            "src/lib.rs",
+            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+        )
+        .await;
 
-    let conflicts =
-        tracker.check_conflicts(repo, "src/lib.rs", session_a, &["fn_a".to_string()]);
+    let conflicts = tracker
+        .check_conflicts(repo, "src/lib.rs", session_a, &["fn_a".to_string()])
+        .await;
     assert!(
         conflicts.is_empty(),
         "same session should not conflict with itself"
     );
 }
 
-#[test]
-fn test_multiple_conflicts() {
-    let tracker = SymbolClaimTracker::new();
+#[tokio::test]
+async fn test_multiple_conflicts() {
+    let tracker = LocalClaimTracker::new();
     let repo = Uuid::new_v4();
     let session_a = Uuid::new_v4();
     let session_b = Uuid::new_v4();
 
-    tracker.record_claim(
-        repo,
-        "src/lib.rs",
-        make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
-    );
-    tracker.record_claim(
-        repo,
-        "src/lib.rs",
-        make_claim(session_a, "agent-1", "fn_b", SymbolKind::Function),
-    );
+    tracker
+        .record_claim(
+            repo,
+            "src/lib.rs",
+            make_claim(session_a, "agent-1", "fn_a", SymbolKind::Function),
+        )
+        .await;
+    tracker
+        .record_claim(
+            repo,
+            "src/lib.rs",
+            make_claim(session_a, "agent-1", "fn_b", SymbolKind::Function),
+        )
+        .await;
 
-    let conflicts = tracker.check_conflicts(
-        repo,
-        "src/lib.rs",
-        session_b,
-        &["fn_a".to_string(), "fn_b".to_string()],
-    );
+    let conflicts = tracker
+        .check_conflicts(
+            repo,
+            "src/lib.rs",
+            session_b,
+            &["fn_a".to_string(), "fn_b".to_string()],
+        )
+        .await;
     assert_eq!(conflicts.len(), 2);
 
     let names: Vec<&str> = conflicts.iter().map(|c| c.qualified_name.as_str()).collect();

--- a/crates/dk-engine/tests/integration/conflict_claim_test.rs
+++ b/crates/dk-engine/tests/integration/conflict_claim_test.rs
@@ -1,5 +1,4 @@
-use std::time::Instant;
-
+use chrono::Utc;
 use dk_core::SymbolKind;
 use dk_engine::conflict::{SymbolClaim, SymbolClaimTracker};
 use uuid::Uuid;
@@ -10,7 +9,7 @@ fn make_claim(session_id: Uuid, agent: &str, name: &str, kind: SymbolKind) -> Sy
         agent_name: agent.to_string(),
         qualified_name: name.to_string(),
         kind,
-        first_touched_at: Instant::now(),
+        first_touched_at: Utc::now(),
     }
 }
 

--- a/crates/dk-protocol/src/file_write.rs
+++ b/crates/dk-protocol/src/file_write.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use tonic::{Response, Status};
 use tracing::{info, warn};
 
@@ -96,7 +94,7 @@ pub async fn handle_file_write(
                 agent_name: agent_name.clone(),
                 qualified_name: sc.symbol_name.clone(),
                 kind,
-                first_touched_at: Instant::now(),
+                first_touched_at: chrono::Utc::now(),
             },
         ) {
             Ok(AcquireOutcome::Fresh) => acquired.push(sc.symbol_name.clone()),

--- a/crates/dk-protocol/src/file_write.rs
+++ b/crates/dk-protocol/src/file_write.rs
@@ -96,7 +96,7 @@ pub async fn handle_file_write(
                 kind,
                 first_touched_at: chrono::Utc::now(),
             },
-        ) {
+        ).await {
             Ok(AcquireOutcome::Fresh) => acquired.push(sc.symbol_name.clone()),
             Ok(AcquireOutcome::ReAcquired) => {} // already held — exclude from rollback
             Err(sl) => {
@@ -125,7 +125,7 @@ pub async fn handle_file_write(
         // Roll back any locks acquired before the failure and emit events
         // so any agent that raced and observed the transient lock can wake up.
         for name in &acquired {
-            server.claim_tracker().release_lock(repo_id, &req.path, sid, name);
+            server.claim_tracker().release_lock(repo_id, &req.path, sid, name).await;
             server.event_bus().publish(crate::WatchEvent {
                 event_type: crate::merge::EVENT_LOCK_RELEASED.to_string(),
                 changeset_id: String::new(),
@@ -164,7 +164,7 @@ pub async fn handle_file_write(
         Some(ws) => ws,
         None => {
             for name in &acquired {
-                server.claim_tracker().release_lock(repo_id, &req.path, sid, name);
+                server.claim_tracker().release_lock(repo_id, &req.path, sid, name).await;
                 server.event_bus().publish(crate::WatchEvent {
                     event_type: crate::merge::EVENT_LOCK_RELEASED.to_string(),
                     changeset_id: String::new(),
@@ -189,7 +189,7 @@ pub async fn handle_file_write(
         Ok(hash) => hash,
         Err(e) => {
             for name in &acquired {
-                server.claim_tracker().release_lock(repo_id, &req.path, sid, name);
+                server.claim_tracker().release_lock(repo_id, &req.path, sid, name).await;
                 server.event_bus().publish(crate::WatchEvent {
                     event_type: crate::merge::EVENT_LOCK_RELEASED.to_string(),
                     changeset_id: String::new(),

--- a/crates/dk-protocol/src/merge.rs
+++ b/crates/dk-protocol/src/merge.rs
@@ -93,7 +93,7 @@ pub async fn handle_merge(
         WorkspaceMergeResult::FastMerge { commit_hash } => {
             // Release locks first — git commit is already in the tree,
             // so locks must be freed regardless of changeset-store state.
-            release_locks_and_emit(server, repo_id, sid, &req.session_id);
+            release_locks_and_emit(server, repo_id, sid, &req.session_id).await;
 
             // Update changeset status to merged
             engine.changeset_store().set_merged(changeset_id, &commit_hash).await
@@ -128,7 +128,7 @@ pub async fn handle_merge(
             auto_rebased_files,
         } => {
             // Release locks first — git commit is already in the tree.
-            release_locks_and_emit(server, repo_id, sid, &req.session_id);
+            release_locks_and_emit(server, repo_id, sid, &req.session_id).await;
 
             // Update changeset status to merged
             engine.changeset_store().set_merged(changeset_id, &commit_hash).await
@@ -210,13 +210,13 @@ pub async fn handle_merge(
 
 /// Release all symbol locks for a session and emit `symbol.lock.released` events
 /// so blocked agents can wake up and retry their writes.
-fn release_locks_and_emit(
+async fn release_locks_and_emit(
     server: &ProtocolServer,
     repo_id: Uuid,
     session_id: Uuid,
     session_id_str: &str,
 ) {
-    let released = server.claim_tracker().release_locks(repo_id, session_id);
+    let released = server.claim_tracker().release_locks(repo_id, session_id).await;
 
     if released.is_empty() {
         return;

--- a/crates/dk-protocol/src/server.rs
+++ b/crates/dk-protocol/src/server.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use dk_engine::conflict::SymbolClaimTracker;
+use dk_engine::conflict::{ClaimTracker, LocalClaimTracker};
 use dk_engine::repo::Engine;
 use tonic::{Request, Response, Status};
 
@@ -18,7 +18,7 @@ pub struct ProtocolServer {
     pub(crate) session_mgr: Arc<SessionManager>,
     pub(crate) auth_config: AuthConfig,
     pub(crate) event_bus: Arc<EventBus>,
-    pub(crate) claim_tracker: Arc<SymbolClaimTracker>,
+    pub(crate) claim_tracker: Arc<dyn ClaimTracker>,
 }
 
 impl ProtocolServer {
@@ -34,7 +34,7 @@ impl ProtocolServer {
             ))),
             auth_config,
             event_bus: Arc::new(EventBus::new()),
-            claim_tracker: Arc::new(SymbolClaimTracker::new()),
+            claim_tracker: Arc::new(LocalClaimTracker::new()),
         }
     }
 
@@ -63,8 +63,25 @@ impl ProtocolServer {
     }
 
     /// Borrow the shared symbol claim tracker.
-    pub fn claim_tracker(&self) -> &SymbolClaimTracker {
-        &self.claim_tracker
+    pub fn claim_tracker(&self) -> &dyn ClaimTracker {
+        &*self.claim_tracker
+    }
+
+    /// Create a `ProtocolServer` with a custom claim tracker implementation.
+    pub fn with_claim_tracker(
+        engine: Arc<Engine>,
+        auth_config: AuthConfig,
+        claim_tracker: Arc<dyn ClaimTracker>,
+    ) -> Self {
+        Self {
+            engine,
+            session_mgr: Arc::new(SessionManager::new(std::time::Duration::from_secs(
+                30 * 60,
+            ))),
+            auth_config,
+            event_bus: Arc::new(EventBus::new()),
+            claim_tracker,
+        }
     }
 
     /// Validate an auth token against the configured secret.


### PR DESCRIPTION
## Summary
- Extract async `ClaimTracker` trait from `SymbolClaimTracker`
- Rename to `LocalClaimTracker` (DashMap, single-pod/tests)
- Add `ValkeyClaimTracker` behind `valkey` feature flag for cross-pod locking
- Lua script for atomic `acquire_lock` (check + set + index in one round-trip)
- Session index set (`sess:{session_id}`) for efficient `release_locks`/`clear_session`
- 2-hour TTL on all keys as safety net for crashed sessions
- Replace `std::time::Instant` with `chrono::DateTime<Utc>` for serializability
- Add `with_claim_tracker` constructor to `ProtocolServer` for DI
- All callers updated to `.await` (file_write.rs, merge.rs)
- All 13 unit tests + 5 integration tests converted to `tokio::test`

## Problem
Symbol locks stored in per-pod DashMap. Session A writes symbol on pod-1, session B writes same symbol on pod-2 — no conflict detected. Session close routed to pod-3 — clears nothing.

## Solution
Valkey-backed tracker shares lock state across all pods. Same API, same semantics, different storage backend.

## Key schema
```
lock:{repo_id}:{file_path}:{qualified_name}  →  JSON SymbolClaim
sess:{session_id}                            →  SET of lock keys
```

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo check -p dk-engine --features valkey` passes
- [ ] CI passes (unit tests, integration tests)
- [ ] Platform bump + deploy + live test with multi-pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)