### PR TITLE
feat: RecordReview RPC + override audit fields + OpenRouter provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yml",
+ "serial_test",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -4446,6 +4447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4485,6 +4495,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -4636,6 +4652,32 @@ dependencies = [
  "ryu",
  "serde",
  "version_check",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/dk-cli/src/commands/agent.rs
+++ b/crates/dk-cli/src/commands/agent.rs
@@ -774,6 +774,8 @@ async fn approve_cmd(server: String, session: String) -> Result<()> {
     let resp = client
         .approve(ApproveRequest {
             session_id: session,
+            override_reason: None,
+            review_snapshot: None,
         })
         .await?
         .into_inner();

--- a/crates/dk-mcp/src/server.rs
+++ b/crates/dk-mcp/src/server.rs
@@ -2312,6 +2312,8 @@ impl DkodMcp {
 
         let request = crate::ApproveRequest {
             session_id: session_id.clone(),
+            override_reason: None,
+            review_snapshot: None,
         };
 
         let response = client

--- a/crates/dk-protocol/proto/dkod/v1/agent.proto
+++ b/crates/dk-protocol/proto/dkod/v1/agent.proto
@@ -476,8 +476,18 @@ message PushResponse {
 
 // --- APPROVE ---
 
+message ReviewSnapshot {
+  int32 score = 1;
+  int32 threshold = 2;
+  int32 findings_count = 3;
+  string provider = 4;       // "anthropic" | "openrouter"
+  string model = 5;
+}
+
 message ApproveRequest {
   string session_id = 1;
+  optional string override_reason = 2;
+  optional ReviewSnapshot review_snapshot = 3;
 }
 
 message ApproveResponse {

--- a/crates/dk-protocol/proto/dkod/v1/agent.proto
+++ b/crates/dk-protocol/proto/dkod/v1/agent.proto
@@ -42,6 +42,9 @@ service AgentService {
 
   // Get code review results for a changeset
   rpc Review(ReviewRequest) returns (ReviewResponse);
+
+  // Record a completed code review result (called by the harness after deep review)
+  rpc RecordReview(RecordReviewRequest) returns (RecordReviewResponse);
 }
 
 // ── CONNECT ──
@@ -357,6 +360,23 @@ message ReviewResultProto {
 
 message ReviewResponse {
   repeated ReviewResultProto reviews = 1;
+}
+
+message RecordReviewRequest {
+  string session_id = 1;
+  string changeset_id = 2;
+  string tier = 3;                                    // "deep"
+  optional int32 score = 4;                           // null when provider errored under strict policy
+  optional string summary = 5;
+  repeated ReviewFindingProto findings = 6;
+  string provider = 7;
+  string model = 8;
+  int64 duration_ms = 9;
+}
+
+message RecordReviewResponse {
+  string review_id = 1;
+  bool accepted = 2;
 }
 
 // --- FILE OPERATIONS ---

--- a/crates/dk-protocol/proto/dkod/v1/agent.proto
+++ b/crates/dk-protocol/proto/dkod/v1/agent.proto
@@ -497,8 +497,8 @@ message PushResponse {
 // --- APPROVE ---
 
 message ReviewSnapshot {
-  int32 score = 1;
-  int32 threshold = 2;
+  optional int32 score = 1;
+  optional int32 threshold = 2;
   uint32 findings_count = 3;
   string provider = 4;       // "anthropic" | "openrouter"
   string model = 5;

--- a/crates/dk-protocol/proto/dkod/v1/agent.proto
+++ b/crates/dk-protocol/proto/dkod/v1/agent.proto
@@ -479,7 +479,7 @@ message PushResponse {
 message ReviewSnapshot {
   int32 score = 1;
   int32 threshold = 2;
-  int32 findings_count = 3;
+  uint32 findings_count = 3;
   string provider = 4;       // "anthropic" | "openrouter"
   string model = 5;
 }

--- a/crates/dk-protocol/src/server.rs
+++ b/crates/dk-protocol/src/server.rs
@@ -257,4 +257,13 @@ impl crate::agent_service_server::AgentService for ProtocolServer {
             "review is a platform-level operation; use the managed server",
         ))
     }
+
+    async fn record_review(
+        &self,
+        _request: Request<crate::RecordReviewRequest>,
+    ) -> Result<Response<crate::RecordReviewResponse>, Status> {
+        Err(Status::unimplemented(
+            "record_review is a platform-level operation; use the managed server",
+        ))
+    }
 }

--- a/crates/dk-protocol/tests/approve_proto_test.rs
+++ b/crates/dk-protocol/tests/approve_proto_test.rs
@@ -6,8 +6,8 @@ fn approve_request_has_override_reason_and_snapshot() {
         session_id: "s1".into(),
         override_reason: Some("Exceeded 3 review fix rounds; findings: X,Y".into()),
         review_snapshot: Some(ReviewSnapshot {
-            score: 2,
-            threshold: 4,
+            score: Some(2),
+            threshold: Some(4),
             findings_count: 3,
             provider: "openrouter".into(),
             model: "anthropic/claude-sonnet-4".into(),
@@ -17,7 +17,7 @@ fn approve_request_has_override_reason_and_snapshot() {
         req.override_reason.as_deref(),
         Some("Exceeded 3 review fix rounds; findings: X,Y")
     );
-    assert_eq!(req.review_snapshot.as_ref().unwrap().score, 2);
+    assert_eq!(req.review_snapshot.as_ref().unwrap().score, Some(2));
 }
 
 #[test]

--- a/crates/dk-protocol/tests/approve_proto_test.rs
+++ b/crates/dk-protocol/tests/approve_proto_test.rs
@@ -1,0 +1,21 @@
+use dk_protocol::{ApproveRequest, ReviewSnapshot};
+
+#[test]
+fn approve_request_has_override_reason_and_snapshot() {
+    let req = ApproveRequest {
+        session_id: "s1".into(),
+        override_reason: Some("Exceeded 3 review fix rounds; findings: X,Y".into()),
+        review_snapshot: Some(ReviewSnapshot {
+            score: 2,
+            threshold: 4,
+            findings_count: 3,
+            provider: "openrouter".into(),
+            model: "anthropic/claude-sonnet-4".into(),
+        }),
+    };
+    assert_eq!(
+        req.override_reason.as_deref(),
+        Some("Exceeded 3 review fix rounds; findings: X,Y")
+    );
+    assert_eq!(req.review_snapshot.as_ref().unwrap().score, 2);
+}

--- a/crates/dk-protocol/tests/approve_proto_test.rs
+++ b/crates/dk-protocol/tests/approve_proto_test.rs
@@ -1,4 +1,4 @@
-use dk_protocol::{ApproveRequest, ReviewSnapshot};
+use dk_protocol::{ApproveRequest, RecordReviewRequest, RecordReviewResponse, ReviewSnapshot};
 
 #[test]
 fn approve_request_has_override_reason_and_snapshot() {
@@ -18,4 +18,31 @@ fn approve_request_has_override_reason_and_snapshot() {
         Some("Exceeded 3 review fix rounds; findings: X,Y")
     );
     assert_eq!(req.review_snapshot.as_ref().unwrap().score, 2);
+}
+
+#[test]
+fn record_review_request_shape() {
+    let req = RecordReviewRequest {
+        session_id: "s1".into(),
+        changeset_id: "c1".into(),
+        tier: "deep".into(),
+        score: Some(4),
+        summary: Some("LGTM with minor warnings".into()),
+        findings: vec![],
+        provider: "anthropic".into(),
+        model: "claude-sonnet-4-6".into(),
+        duration_ms: 12345,
+    };
+    assert_eq!(req.tier, "deep");
+    assert_eq!(req.score, Some(4));
+    assert_eq!(req.duration_ms, 12345);
+}
+
+#[test]
+fn record_review_response_shape() {
+    let resp = RecordReviewResponse {
+        review_id: "r1".into(),
+        accepted: true,
+    };
+    assert!(resp.accepted);
 }

--- a/crates/dk-runner/Cargo.toml
+++ b/crates/dk-runner/Cargo.toml
@@ -29,3 +29,4 @@ reqwest = { version = "0.12", features = ["json"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
+serial_test = "3"

--- a/crates/dk-runner/src/steps/agent_review/claude.rs
+++ b/crates/dk-runner/src/steps/agent_review/claude.rs
@@ -61,7 +61,7 @@ struct ContentBlock {
 #[async_trait::async_trait]
 impl ReviewProvider for ClaudeReviewProvider {
     fn name(&self) -> &str {
-        "claude"
+        "anthropic"
     }
 
     async fn review(&self, request: ReviewRequest) -> Result<ReviewResponse> {

--- a/crates/dk-runner/src/steps/agent_review/mod.rs
+++ b/crates/dk-runner/src/steps/agent_review/mod.rs
@@ -99,8 +99,7 @@ pub fn select_provider_from_env() -> Option<Box<dyn provider::ReviewProvider>> {
         return openrouter::OpenRouterReviewProvider::from_env()
             .map(|p| Box::new(p) as Box<dyn provider::ReviewProvider>);
     }
-    if std::env::var("DKOD_ANTHROPIC_API_KEY").is_ok() {
-        let key = std::env::var("DKOD_ANTHROPIC_API_KEY").ok()?;
+    if let Ok(key) = std::env::var("DKOD_ANTHROPIC_API_KEY") {
         let model = std::env::var("DKOD_REVIEW_MODEL").ok();
         return claude::ClaudeReviewProvider::new(key, model, None)
             .ok()
@@ -119,30 +118,28 @@ mod provider_factory_tests {
         }
     }
 
-    #[tokio::test]
+    #[test]
     #[serial_test::serial]
-    async fn openrouter_wins_when_both_keys_set() {
+    fn openrouter_wins_when_both_keys_set() {
         clear();
         std::env::set_var("DKOD_ANTHROPIC_API_KEY", "sk-ant");
         std::env::set_var("DKOD_OPENROUTER_API_KEY", "sk-or");
         let p = select_provider_from_env().expect("expected a provider");
         assert_eq!(p.name(), "openrouter");
-        clear();
     }
 
-    #[tokio::test]
+    #[test]
     #[serial_test::serial]
-    async fn anthropic_selected_when_only_anthropic_set() {
+    fn anthropic_selected_when_only_anthropic_set() {
         clear();
         std::env::set_var("DKOD_ANTHROPIC_API_KEY", "sk-ant");
         let p = select_provider_from_env().expect("expected a provider");
         assert_eq!(p.name(), "claude");
-        clear();
     }
 
-    #[tokio::test]
+    #[test]
     #[serial_test::serial]
-    async fn none_when_no_keys() {
+    fn none_when_no_keys() {
         clear();
         assert!(select_provider_from_env().is_none());
     }

--- a/crates/dk-runner/src/steps/agent_review/mod.rs
+++ b/crates/dk-runner/src/steps/agent_review/mod.rs
@@ -1,5 +1,6 @@
 pub mod provider;
 pub mod claude;
+pub mod openrouter;
 pub mod prompt;
 pub mod parse;
 

--- a/crates/dk-runner/src/steps/agent_review/mod.rs
+++ b/crates/dk-runner/src/steps/agent_review/mod.rs
@@ -85,6 +85,69 @@ pub async fn run_agent_review_step(prompt: &str) -> StepOutput {
     }
 }
 
+/// Select a `ReviewProvider` based on environment variables.
+///
+/// Precedence:
+/// 1. `DKOD_OPENROUTER_API_KEY` → `OpenRouterReviewProvider`
+/// 2. `DKOD_ANTHROPIC_API_KEY`  → `ClaudeReviewProvider`
+/// 3. Neither                    → `None`
+///
+/// When both keys are set, OpenRouter wins (single routing point for
+/// cost tracking + model flexibility).
+pub fn select_provider_from_env() -> Option<Box<dyn provider::ReviewProvider>> {
+    if std::env::var("DKOD_OPENROUTER_API_KEY").is_ok() {
+        return openrouter::OpenRouterReviewProvider::from_env()
+            .map(|p| Box::new(p) as Box<dyn provider::ReviewProvider>);
+    }
+    if std::env::var("DKOD_ANTHROPIC_API_KEY").is_ok() {
+        let key = std::env::var("DKOD_ANTHROPIC_API_KEY").ok()?;
+        let model = std::env::var("DKOD_REVIEW_MODEL").ok();
+        return claude::ClaudeReviewProvider::new(key, model, None)
+            .ok()
+            .map(|p| Box::new(p) as Box<dyn provider::ReviewProvider>);
+    }
+    None
+}
+
+#[cfg(test)]
+mod provider_factory_tests {
+    use super::select_provider_from_env;
+
+    fn clear() {
+        for k in ["DKOD_ANTHROPIC_API_KEY", "DKOD_OPENROUTER_API_KEY", "DKOD_REVIEW_MODEL", "DKOD_OPENROUTER_BASE_URL"] {
+            std::env::remove_var(k);
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn openrouter_wins_when_both_keys_set() {
+        clear();
+        std::env::set_var("DKOD_ANTHROPIC_API_KEY", "sk-ant");
+        std::env::set_var("DKOD_OPENROUTER_API_KEY", "sk-or");
+        let p = select_provider_from_env().expect("expected a provider");
+        assert_eq!(p.name(), "openrouter");
+        clear();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn anthropic_selected_when_only_anthropic_set() {
+        clear();
+        std::env::set_var("DKOD_ANTHROPIC_API_KEY", "sk-ant");
+        let p = select_provider_from_env().expect("expected a provider");
+        assert_eq!(p.name(), "claude");
+        clear();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn none_when_no_keys() {
+        clear();
+        assert!(select_provider_from_env().is_none());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/dk-runner/src/steps/agent_review/mod.rs
+++ b/crates/dk-runner/src/steps/agent_review/mod.rs
@@ -96,14 +96,26 @@ pub async fn run_agent_review_step(prompt: &str) -> StepOutput {
 /// cost tracking + model flexibility).
 pub fn select_provider_from_env() -> Option<Box<dyn provider::ReviewProvider>> {
     if std::env::var("DKOD_OPENROUTER_API_KEY").is_ok() {
-        return openrouter::OpenRouterReviewProvider::from_env()
+        let provider = openrouter::OpenRouterReviewProvider::from_env()
             .map(|p| Box::new(p) as Box<dyn provider::ReviewProvider>);
+        if provider.is_none() {
+            tracing::warn!(
+                "DKOD_OPENROUTER_API_KEY is set but OpenRouterReviewProvider failed to initialise; no review provider active"
+            );
+        }
+        return provider;
     }
     if let Ok(key) = std::env::var("DKOD_ANTHROPIC_API_KEY") {
         let model = std::env::var("DKOD_REVIEW_MODEL").ok();
-        return claude::ClaudeReviewProvider::new(key, model, None)
+        let provider = claude::ClaudeReviewProvider::new(key, model, None)
             .ok()
             .map(|p| Box::new(p) as Box<dyn provider::ReviewProvider>);
+        if provider.is_none() {
+            tracing::warn!(
+                "DKOD_ANTHROPIC_API_KEY is set but ClaudeReviewProvider failed to initialise; no review provider active"
+            );
+        }
+        return provider;
     }
     None
 }
@@ -134,7 +146,7 @@ mod provider_factory_tests {
         clear();
         std::env::set_var("DKOD_ANTHROPIC_API_KEY", "sk-ant");
         let p = select_provider_from_env().expect("expected a provider");
-        assert_eq!(p.name(), "claude");
+        assert_eq!(p.name(), "anthropic");
     }
 
     #[test]

--- a/crates/dk-runner/src/steps/agent_review/openrouter.rs
+++ b/crates/dk-runner/src/steps/agent_review/openrouter.rs
@@ -1,0 +1,142 @@
+use std::time::Duration;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use super::parse::parse_review_response;
+use super::prompt::build_review_prompt;
+use super::provider::{ReviewProvider, ReviewRequest, ReviewResponse};
+
+pub struct OpenRouterReviewProvider {
+    client: reqwest::Client,
+    api_key: String,
+    model: String,
+    max_tokens: usize,
+    base_url: String,
+}
+
+impl OpenRouterReviewProvider {
+    pub fn new(
+        api_key: String,
+        model: Option<String>,
+        max_tokens: Option<usize>,
+        base_url: Option<String>,
+    ) -> Result<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(120))
+            .build()?;
+        Ok(Self {
+            client,
+            api_key,
+            model: model.unwrap_or_else(|| "anthropic/claude-sonnet-4".to_string()),
+            max_tokens: max_tokens.unwrap_or(4096),
+            base_url: base_url.unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string()),
+        })
+    }
+
+    pub fn from_env() -> Option<Self> {
+        let api_key = std::env::var("DKOD_OPENROUTER_API_KEY").ok()?;
+        let model = std::env::var("DKOD_REVIEW_MODEL").ok();
+        let base_url = std::env::var("DKOD_OPENROUTER_BASE_URL").ok();
+        Self::new(api_key, model, None, base_url).ok()
+    }
+}
+
+#[derive(Serialize)]
+struct ChatRequest {
+    model: String,
+    max_tokens: usize,
+    messages: Vec<ChatMessage>,
+}
+
+#[derive(Serialize)]
+struct ChatMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct ChatResponse {
+    choices: Vec<Choice>,
+}
+
+#[derive(Deserialize)]
+struct Choice {
+    message: ResponseMessage,
+}
+
+#[derive(Deserialize)]
+struct ResponseMessage {
+    content: String,
+}
+
+#[async_trait::async_trait]
+impl ReviewProvider for OpenRouterReviewProvider {
+    fn name(&self) -> &str {
+        "openrouter"
+    }
+
+    async fn review(&self, request: ReviewRequest) -> Result<ReviewResponse> {
+        let prompt = build_review_prompt(&request);
+        let resp = self
+            .client
+            .post(format!("{}/chat/completions", self.base_url))
+            .bearer_auth(&self.api_key)
+            .header("HTTP-Referer", "https://dkod.io")
+            .header("X-Title", "dkod code review")
+            .json(&ChatRequest {
+                model: self.model.clone(),
+                max_tokens: self.max_tokens,
+                messages: vec![ChatMessage {
+                    role: "user".to_string(),
+                    content: prompt,
+                }],
+            })
+            .send()
+            .await
+            .context("Failed to call OpenRouter API")?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("OpenRouter API returned {status}: {body}");
+        }
+        let api_resp: ChatResponse = resp
+            .json()
+            .await
+            .context("Failed to parse OpenRouter API response")?;
+        let text = api_resp
+            .choices
+            .into_iter()
+            .next()
+            .map(|c| c.message.content)
+            .unwrap_or_default();
+        parse_review_response(&text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OpenRouterReviewProvider;
+    use crate::steps::agent_review::provider::ReviewProvider;
+
+    fn clear() {
+        for k in ["DKOD_OPENROUTER_API_KEY", "DKOD_REVIEW_MODEL", "DKOD_OPENROUTER_BASE_URL"] {
+            std::env::remove_var(k);
+        }
+    }
+
+    #[serial_test::serial]
+    #[tokio::test]
+    async fn from_env_returns_none_without_key() {
+        clear();
+        assert!(OpenRouterReviewProvider::from_env().is_none());
+    }
+
+    #[serial_test::serial]
+    #[tokio::test]
+    async fn from_env_builds_provider_with_key() {
+        clear();
+        std::env::set_var("DKOD_OPENROUTER_API_KEY", "sk-test");
+        let p = OpenRouterReviewProvider::from_env().unwrap();
+        assert_eq!(p.name(), "openrouter");
+        clear();
+    }
+}

--- a/proto/dkod/v1/agent.proto
+++ b/proto/dkod/v1/agent.proto
@@ -476,8 +476,18 @@ message PushResponse {
 
 // --- APPROVE ---
 
+message ReviewSnapshot {
+  int32 score = 1;
+  int32 threshold = 2;
+  int32 findings_count = 3;
+  string provider = 4;       // "anthropic" | "openrouter"
+  string model = 5;
+}
+
 message ApproveRequest {
   string session_id = 1;
+  optional string override_reason = 2;
+  optional ReviewSnapshot review_snapshot = 3;
 }
 
 message ApproveResponse {

--- a/proto/dkod/v1/agent.proto
+++ b/proto/dkod/v1/agent.proto
@@ -42,6 +42,9 @@ service AgentService {
 
   // Get code review results for a changeset
   rpc Review(ReviewRequest) returns (ReviewResponse);
+
+  // Record a completed code review result (called by the harness after deep review)
+  rpc RecordReview(RecordReviewRequest) returns (RecordReviewResponse);
 }
 
 // ── CONNECT ──
@@ -357,6 +360,23 @@ message ReviewResultProto {
 
 message ReviewResponse {
   repeated ReviewResultProto reviews = 1;
+}
+
+message RecordReviewRequest {
+  string session_id = 1;
+  string changeset_id = 2;
+  string tier = 3;                                    // "deep"
+  optional int32 score = 4;                           // null when provider errored under strict policy
+  optional string summary = 5;
+  repeated ReviewFindingProto findings = 6;
+  string provider = 7;
+  string model = 8;
+  int64 duration_ms = 9;
+}
+
+message RecordReviewResponse {
+  string review_id = 1;
+  bool accepted = 2;
 }
 
 // --- FILE OPERATIONS ---

--- a/proto/dkod/v1/agent.proto
+++ b/proto/dkod/v1/agent.proto
@@ -497,8 +497,8 @@ message PushResponse {
 // --- APPROVE ---
 
 message ReviewSnapshot {
-  int32 score = 1;
-  int32 threshold = 2;
+  optional int32 score = 1;
+  optional int32 threshold = 2;
   uint32 findings_count = 3;
   string provider = 4;       // "anthropic" | "openrouter"
   string model = 5;

--- a/proto/dkod/v1/agent.proto
+++ b/proto/dkod/v1/agent.proto
@@ -479,7 +479,7 @@ message PushResponse {
 message ReviewSnapshot {
   int32 score = 1;
   int32 threshold = 2;
-  int32 findings_count = 3;
+  uint32 findings_count = 3;
   string provider = 4;       // "anthropic" | "openrouter"
   string model = 5;
 }


### PR DESCRIPTION
## Summary
- Adds `RecordReview` gRPC for clients that drive their own deep review (BYOK-at-client pattern). Stub handler returns `Status::unimplemented` — the real persistence lives in the platform repo and lands in a follow-up PR after this is tagged.
- Extends `ApproveRequest` with optional `override_reason` + `ReviewSnapshot` for the force-approve audit trail (engine stub unchanged; platform PR consumes them).
- New `OpenRouterReviewProvider` mirroring `ClaudeReviewProvider` — OpenAI-compatible chat/completions against OpenRouter, reads `DKOD_OPENROUTER_API_KEY`, default model `anthropic/claude-sonnet-4`, overridable via `DKOD_OPENROUTER_BASE_URL`.
- New provider factory `select_provider_from_env()` with OpenRouter-wins precedence when both keys are set. Reads the new opt-in vars `DKOD_ANTHROPIC_API_KEY` / `DKOD_OPENROUTER_API_KEY` (distinct from engine-internal `DKOD_REVIEW_API_KEY`).

## Scope (dormant capability)
No user-visible behavior change — this PR ships the building blocks. PR 2 (`dk-mcp` gate, separate) turns them on behind `DKOD_CODE_REVIEW=1`.

## Rollout sequence
1. **This PR** lands → cut tag v0.2.80
2. **Platform PR** (dkod-io/dkod-platform) implements real `record_review` handler + persists `override_reason`/`review_snapshot` on `approve`
3. **PR 2** (`feat/mcp-code-review-gate`) in this repo wires the gate in dk-mcp

## Design / Plan
- Design: \`docs/plans/2026-04-16-mcp-code-review-gate-design.md\` (separate PR #68)
- Plan: \`docs/plans/2026-04-16-mcp-code-review-gate-plan.md\` (same PR as design)

## Test plan
- [x] \`cargo build --workspace\` clean
- [x] \`cargo test -p dk-protocol\` — 3 new tests pass (ApproveRequest/ReviewSnapshot shape + RecordReviewRequest/Response shape)
- [x] \`cargo test -p dk-runner\` — 2 new tests pass (OpenRouter from_env), 3 new tests pass (factory precedence), 0 regressions
- [x] Existing callsites updated: \`dk-mcp/src/server.rs\` + \`dk-cli/src/commands/agent.rs\` get \`override_reason: None, review_snapshot: None\` on \`ApproveRequest {}\` struct literals
- [x] Both proto copies (\`proto/\` and \`crates/dk-protocol/proto/\`) byte-identical in edited regions (CI sync check)

## Review notes
- \`findings_count: uint32\` in \`ReviewSnapshot\` (non-negative by definition)
- \`serial_test\` added to \`dk-runner\` dev-deps for env-var test isolation