### PR TITLE
feat: MCP-layer code review gate (opt-in via DKOD_CODE_REVIEW=1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-nats",
+ "async-trait",
  "chrono",
  "dirs",
  "dk-runner",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,6 +949,7 @@ dependencies = [
  "async-nats",
  "chrono",
  "dirs",
+ "dk-runner",
  "open",
  "prost",
  "prost-types",

--- a/crates/dk-mcp/Cargo.toml
+++ b/crates/dk-mcp/Cargo.toml
@@ -29,6 +29,7 @@ open = "5"
 dirs = "6"
 chrono = { workspace = true }
 async-nats = "0.38"
+dk-runner = { path = "../dk-runner" }
 
 [dev-dependencies]
 rmcp = { version = "0.16", features = ["client", "server", "transport-io"] }

--- a/crates/dk-mcp/Cargo.toml
+++ b/crates/dk-mcp/Cargo.toml
@@ -29,10 +29,14 @@ open = "5"
 dirs = "6"
 chrono = { workspace = true }
 async-nats = "0.38"
+async-trait = { workspace = true }
 dk-runner = { path = "../dk-runner" }
 
 [dev-dependencies]
 rmcp = { version = "0.16", features = ["client", "server", "transport-io"] }
+
+[features]
+mock-review = []
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/crates/dk-mcp/src/lib.rs
+++ b/crates/dk-mcp/src/lib.rs
@@ -11,5 +11,6 @@ pub use proto::dkod::v1::*;
 pub mod auth;
 pub mod grpc;
 pub mod retry;
+pub mod review_gate;
 pub mod server;
 pub mod state;

--- a/crates/dk-mcp/src/lib.rs
+++ b/crates/dk-mcp/src/lib.rs
@@ -12,5 +12,7 @@ pub mod auth;
 pub mod grpc;
 pub mod retry;
 pub mod review_gate;
+#[cfg(any(test, feature = "mock-review"))]
+pub mod review_gate_mock;
 pub mod server;
 pub mod state;

--- a/crates/dk-mcp/src/main.rs
+++ b/crates/dk-mcp/src/main.rs
@@ -13,6 +13,11 @@ async fn main() -> Result<()> {
         .with_ansi(false)
         .init();
 
+    // Emit any gate-config warnings once, at startup.
+    for warning in dk_mcp::review_gate::startup_warnings(&dk_mcp::review_gate::GateConfig::from_env()) {
+        eprintln!("{}", warning);
+    }
+
     let server = dk_mcp::server::DkodMcp::new().await;
     let service = server.serve(stdio()).await?;
     service.waiting().await?;

--- a/crates/dk-mcp/src/review_gate.rs
+++ b/crates/dk-mcp/src/review_gate.rs
@@ -72,6 +72,31 @@ pub enum GateOutcome {
     Reject(String),
 }
 
+/// Serializable projection of [`crate::ReviewFindingProto`] for embedding in
+/// gate rejection payloads. prost-generated types do not derive `Serialize`,
+/// so we hand-copy the fields we want to surface.
+#[derive(serde::Serialize)]
+struct FindingJson<'a> {
+    severity: &'a str,
+    category: &'a str,
+    message: &'a str,
+    file_path: &'a str,
+    line_start: Option<i32>,
+}
+
+fn findings_to_json(findings: &[crate::ReviewFindingProto]) -> Vec<FindingJson<'_>> {
+    findings
+        .iter()
+        .map(|f| FindingJson {
+            severity: &f.severity,
+            category: &f.category,
+            message: &f.message,
+            file_path: &f.file_path,
+            line_start: f.line_start,
+        })
+        .collect()
+}
+
 /// Evaluate the gate for a `dk_approve` call.
 ///
 /// - `!cfg.enabled` → `Pass` (no gate).
@@ -80,8 +105,11 @@ pub enum GateOutcome {
 /// - `cfg.misconfigured()` → `Reject` with a `gate_misconfigured` payload.
 /// - `deep_review` is `None` → `Reject` with a `deep_review_pending` payload
 ///   that instructs the caller to retry in ~15 seconds.
-/// - `deep_review` is `Some(_)` → `Pass` (score-based checks are layered on
-///   in later tasks).
+/// - `deep_review` is `Some(r)` with `r.score` = `None` → `Reject` with a
+///   `review_provider_error` payload (retry in 60s, can_override).
+/// - `deep_review` is `Some(r)` with `r.score < cfg.min_score` → `Reject` with
+///   a `review_score_below_threshold` payload including the inline findings.
+/// - `deep_review` is `Some(r)` with `r.score >= cfg.min_score` → `Pass`.
 pub fn evaluate_gate(
     cfg: &GateConfig,
     force: bool,
@@ -100,7 +128,7 @@ pub fn evaluate_gate(
         });
         return GateOutcome::Reject(body.to_string());
     }
-    if deep_review.is_none() {
+    let Some(r) = deep_review else {
         let body = serde_json::json!({
             "error": "deep_review_pending",
             "message": "Deep code review has not completed yet. Retry dk_approve in ~15s, or poll dk_review.",
@@ -111,8 +139,45 @@ pub fn evaluate_gate(
             },
         });
         return GateOutcome::Reject(body.to_string());
+    };
+    let findings_val =
+        serde_json::to_value(findings_to_json(&r.findings)).unwrap_or(serde_json::Value::Null);
+    match r.score {
+        None => {
+            let body = serde_json::json!({
+                "error": "review_provider_error",
+                "message": "Deep review failed due to provider error. See findings.",
+                "findings": findings_val,
+                "next_action": {
+                    "kind": "wait_and_retry",
+                    "retry_after_secs": 60,
+                    "can_fix": false,
+                    "can_override": true,
+                },
+            });
+            GateOutcome::Reject(body.to_string())
+        }
+        Some(score) if score < cfg.min_score => {
+            let body = serde_json::json!({
+                "error": "review_score_below_threshold",
+                "message": format!(
+                    "Deep review score {}/5 is below required {}/5. Fix the findings below and resubmit.",
+                    score, cfg.min_score
+                ),
+                "score": score,
+                "threshold": cfg.min_score,
+                "findings": findings_val,
+                "next_action": {
+                    "kind": "fix_and_resubmit",
+                    "can_fix": true,
+                    "can_override": true,
+                    "override_hint": "If the findings are false positives, call dk_approve(force: true, override_reason: '...').",
+                },
+            });
+            GateOutcome::Reject(body.to_string())
+        }
+        Some(_) => GateOutcome::Pass,
     }
-    GateOutcome::Pass
 }
 
 impl GateConfig {
@@ -539,6 +604,54 @@ mod evaluate_gate_tests {
         assert!(body.contains("deep_review_pending"));
         assert!(body.contains("\"retry_after_secs\":15"));
         assert!(body.contains("\"can_fix\":false"));
+    }
+
+    fn deep(score: Option<i32>, findings: Vec<crate::ReviewFindingProto>) -> ReviewResultProto {
+        ReviewResultProto {
+            id: "r1".into(),
+            tier: "deep".into(),
+            score,
+            summary: None,
+            findings,
+            created_at: "".into(),
+        }
+    }
+
+    #[test]
+    fn reject_below_threshold() {
+        let r = deep(Some(2), vec![]);
+        let GateOutcome::Reject(body) = evaluate_gate(&cfg_on(), false, Some(&r)) else {
+            panic!()
+        };
+        assert!(body.contains("review_score_below_threshold"));
+        assert!(body.contains("\"score\":2"));
+        assert!(body.contains("\"threshold\":4"));
+        assert!(body.contains("fix_and_resubmit"));
+    }
+    #[test]
+    fn reject_provider_error_when_score_none() {
+        let r = deep(None, vec![]);
+        let GateOutcome::Reject(body) = evaluate_gate(&cfg_on(), false, Some(&r)) else {
+            panic!()
+        };
+        assert!(body.contains("review_provider_error"));
+        assert!(body.contains("\"retry_after_secs\":60"));
+    }
+    #[test]
+    fn pass_at_threshold_exactly() {
+        let r = deep(Some(4), vec![]);
+        assert!(matches!(
+            evaluate_gate(&cfg_on(), false, Some(&r)),
+            GateOutcome::Pass
+        ));
+    }
+    #[test]
+    fn pass_above_threshold() {
+        let r = deep(Some(5), vec![]);
+        assert!(matches!(
+            evaluate_gate(&cfg_on(), false, Some(&r)),
+            GateOutcome::Pass
+        ));
     }
 }
 

--- a/crates/dk-mcp/src/review_gate.rs
+++ b/crates/dk-mcp/src/review_gate.rs
@@ -119,7 +119,10 @@ fn finding_to_proto(finding: &Finding) -> crate::ReviewFindingProto {
         category: finding.check_name.clone(),
         message: finding.message.clone(),
         suggestion: None,
-        confidence: 0.0,
+        // Providers don't surface per-finding probabilities today; `1.0` treats
+        // the finding as fully returned (the LLM did surface it) rather than
+        // `0.0` which would mean "no confidence" and is semantically wrong.
+        confidence: 1.0,
         dismissed: false,
     }
 }
@@ -281,7 +284,14 @@ pub async fn run_background_review(
         &cfg,
     ) {
         Some(r) => r,
-        None => return, // degraded policy — fall back silently
+        None => {
+            tracing::debug!(
+                session_id = %session_id,
+                changeset_id = %changeset_id,
+                "background review: provider errored under degraded policy — skipping record"
+            );
+            return;
+        }
     };
 
     let mut client = match connect_grpc(grpc_addr, auth_token).await {

--- a/crates/dk-mcp/src/review_gate.rs
+++ b/crates/dk-mcp/src/review_gate.rs
@@ -117,8 +117,10 @@ pub fn validate_override_reason(reason: Option<&str>) -> OverrideReasonValidatio
 /// `dk_approve(force: true)` was called.
 ///
 /// When no deep review exists (provider not yet finished, background spawn
-/// failed, etc.) the snapshot records `score = Some(0)`, `findings_count = 0`,
+/// failed, etc.) the snapshot records `score = None`, `findings_count = 0`,
 /// and the configured threshold so the audit row is still self-describing.
+/// `None` is distinct from `Some(0)`, which is reserved for "provider errored
+/// under strict backoff policy". Audit consumers rely on this distinction.
 /// The `provider` and `model` fields are taken from [`GateConfig`] rather than
 /// the review result because the review result has no provider field.
 pub fn build_review_snapshot(
@@ -279,16 +281,27 @@ impl GateConfig {
     ///
     /// Reads seven variables: `DKOD_CODE_REVIEW` (enable flag; only `"1"` enables),
     /// `DKOD_OPENROUTER_API_KEY` and `DKOD_ANTHROPIC_API_KEY` (provider selection —
-    /// OpenRouter wins when both are set), `DKOD_REVIEW_MIN_SCORE` (default 4,
+    /// OpenRouter wins when both are set; empty-string values are treated as
+    /// absent so a stray `DKOD_OPENROUTER_API_KEY=""` does not mask a real
+    /// Anthropic key), `DKOD_REVIEW_MIN_SCORE` (default 4,
     /// valid 1..=5), `DKOD_REVIEW_TIMEOUT_SECS` (default 180),
     /// `DKOD_REVIEW_BACKOFF_POLICY` (`"degraded"` selects [`BackoffPolicy::Degraded`];
     /// anything else — including unset — is [`BackoffPolicy::Strict`]), and
     /// `DKOD_REVIEW_MODEL` (optional model override, forwarded to the provider).
     pub fn from_env() -> Self {
         let enabled = std::env::var("DKOD_CODE_REVIEW").map(|v| v == "1").unwrap_or(false);
-        let provider_name = if std::env::var("DKOD_OPENROUTER_API_KEY").is_ok() {
+        // Treat empty-string env vars as absent so that e.g.
+        // `DKOD_OPENROUTER_API_KEY=""` + a real `DKOD_ANTHROPIC_API_KEY`
+        // selects anthropic instead of a silent wrong-provider failure.
+        let has_openrouter = std::env::var("DKOD_OPENROUTER_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+        let has_anthropic = std::env::var("DKOD_ANTHROPIC_API_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+        let provider_name = if has_openrouter {
             Some("openrouter".to_string())
-        } else if std::env::var("DKOD_ANTHROPIC_API_KEY").is_ok() {
+        } else if has_anthropic {
             Some("anthropic".to_string())
         } else {
             None
@@ -595,6 +608,40 @@ mod env_parsing_tests {
         std::env::set_var("DKOD_REVIEW_MIN_SCORE", "banana");
         let cfg = GateConfig::from_env();
         assert_eq!(cfg.min_score, 4);
+        clear_all();
+    }
+
+    #[test]
+    fn empty_provider_key_treated_as_absent() {
+        // Regression: `std::env::var(...).is_ok()` returned true for an empty
+        // string, suppressing `gate_misconfigured` and letting an empty
+        // OpenRouter key mask a real Anthropic key. Empty string must now be
+        // treated as absent.
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_all();
+        std::env::set_var("DKOD_CODE_REVIEW", "1");
+        std::env::set_var("DKOD_OPENROUTER_API_KEY", "");
+        std::env::set_var("DKOD_ANTHROPIC_API_KEY", "");
+        let cfg = GateConfig::from_env();
+        assert!(cfg.enabled);
+        assert!(cfg.provider_name.is_none(), "empty strings must not select a provider");
+        assert!(cfg.misconfigured(), "empty provider keys must surface as gate_misconfigured");
+        clear_all();
+    }
+
+    #[test]
+    fn empty_openrouter_key_falls_back_to_anthropic() {
+        // Regression: an empty `DKOD_OPENROUTER_API_KEY` must not win over a
+        // real `DKOD_ANTHROPIC_API_KEY`; precedence only applies when
+        // OpenRouter has a non-empty value.
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_all();
+        std::env::set_var("DKOD_CODE_REVIEW", "1");
+        std::env::set_var("DKOD_OPENROUTER_API_KEY", "");
+        std::env::set_var("DKOD_ANTHROPIC_API_KEY", "sk-ant");
+        let cfg = GateConfig::from_env();
+        assert_eq!(cfg.provider_name.as_deref(), Some("anthropic"));
+        assert!(!cfg.misconfigured());
         clear_all();
     }
 }

--- a/crates/dk-mcp/src/review_gate.rs
+++ b/crates/dk-mcp/src/review_gate.rs
@@ -1,0 +1,130 @@
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct GateConfig {
+    pub enabled: bool,
+    pub provider_name: Option<String>,    // None if flag set but no key
+    pub min_score: i32,
+    pub timeout: Duration,
+    pub backoff_policy: BackoffPolicy,
+    pub model: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackoffPolicy { Strict, Degraded }
+
+impl GateConfig {
+    pub fn from_env() -> Self {
+        let enabled = std::env::var("DKOD_CODE_REVIEW").map(|v| v == "1").unwrap_or(false);
+        let provider_name = if std::env::var("DKOD_OPENROUTER_API_KEY").is_ok() {
+            Some("openrouter".to_string())
+        } else if std::env::var("DKOD_ANTHROPIC_API_KEY").is_ok() {
+            Some("anthropic".to_string())
+        } else {
+            None
+        };
+        let min_score = std::env::var("DKOD_REVIEW_MIN_SCORE")
+            .ok().and_then(|s| s.parse().ok())
+            .filter(|&n: &i32| (1..=5).contains(&n))
+            .unwrap_or(4);
+        let timeout = std::env::var("DKOD_REVIEW_TIMEOUT_SECS")
+            .ok().and_then(|s| s.parse::<u64>().ok())
+            .map(Duration::from_secs)
+            .unwrap_or(Duration::from_secs(180));
+        let backoff_policy = match std::env::var("DKOD_REVIEW_BACKOFF_POLICY").as_deref() {
+            Ok("degraded") => BackoffPolicy::Degraded,
+            _ => BackoffPolicy::Strict,
+        };
+        let model = std::env::var("DKOD_REVIEW_MODEL").ok();
+        Self { enabled, provider_name, min_score, timeout, backoff_policy, model }
+    }
+
+    pub fn misconfigured(&self) -> bool {
+        self.enabled && self.provider_name.is_none()
+    }
+}
+
+#[cfg(test)]
+mod env_parsing_tests {
+    use super::GateConfig;
+    use std::sync::Mutex;
+
+    // Tests mutate process-global env vars; serialize to avoid cross-test races.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear_all() {
+        for k in ["DKOD_CODE_REVIEW", "DKOD_ANTHROPIC_API_KEY", "DKOD_OPENROUTER_API_KEY",
+                  "DKOD_REVIEW_MIN_SCORE", "DKOD_REVIEW_TIMEOUT_SECS",
+                  "DKOD_REVIEW_BACKOFF_POLICY", "DKOD_REVIEW_MODEL"] {
+            std::env::remove_var(k);
+        }
+    }
+
+    #[test]
+    fn disabled_when_flag_unset() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_all();
+        assert!(!GateConfig::from_env().enabled);
+    }
+
+    #[test]
+    fn enabled_with_anthropic_key() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_all();
+        std::env::set_var("DKOD_CODE_REVIEW", "1");
+        std::env::set_var("DKOD_ANTHROPIC_API_KEY", "sk-ant");
+        let cfg = GateConfig::from_env();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.provider_name.as_deref(), Some("anthropic"));
+        assert_eq!(cfg.min_score, 4);
+        clear_all();
+    }
+
+    #[test]
+    fn misconfigured_when_flag_set_but_no_key() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_all();
+        std::env::set_var("DKOD_CODE_REVIEW", "1");
+        let cfg = GateConfig::from_env();
+        assert!(cfg.enabled);
+        assert!(cfg.provider_name.is_none());
+        assert!(cfg.misconfigured());
+        clear_all();
+    }
+
+    #[test]
+    fn openrouter_wins_when_both_set() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_all();
+        std::env::set_var("DKOD_CODE_REVIEW", "1");
+        std::env::set_var("DKOD_ANTHROPIC_API_KEY", "sk-ant");
+        std::env::set_var("DKOD_OPENROUTER_API_KEY", "sk-or");
+        let cfg = GateConfig::from_env();
+        assert_eq!(cfg.provider_name.as_deref(), Some("openrouter"));
+        clear_all();
+    }
+
+    #[test]
+    fn min_score_overridable() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_all();
+        std::env::set_var("DKOD_CODE_REVIEW", "1");
+        std::env::set_var("DKOD_ANTHROPIC_API_KEY", "sk-ant");
+        std::env::set_var("DKOD_REVIEW_MIN_SCORE", "5");
+        let cfg = GateConfig::from_env();
+        assert_eq!(cfg.min_score, 5);
+        clear_all();
+    }
+
+    #[test]
+    fn min_score_invalid_falls_back_to_default() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_all();
+        std::env::set_var("DKOD_CODE_REVIEW", "1");
+        std::env::set_var("DKOD_ANTHROPIC_API_KEY", "sk-ant");
+        std::env::set_var("DKOD_REVIEW_MIN_SCORE", "banana");
+        let cfg = GateConfig::from_env();
+        assert_eq!(cfg.min_score, 4);
+        clear_all();
+    }
+}

--- a/crates/dk-mcp/src/review_gate.rs
+++ b/crates/dk-mcp/src/review_gate.rs
@@ -287,7 +287,10 @@ impl GateConfig {
     /// valid 1..=5), `DKOD_REVIEW_TIMEOUT_SECS` (default 180),
     /// `DKOD_REVIEW_BACKOFF_POLICY` (`"degraded"` selects [`BackoffPolicy::Degraded`];
     /// anything else — including unset — is [`BackoffPolicy::Strict`]), and
-    /// `DKOD_REVIEW_MODEL` (optional model override, forwarded to the provider).
+    /// `DKOD_REVIEW_MODEL` (optional model override — read independently by
+    /// both this function and the provider's own `from_env`/constructor, so
+    /// the value recorded in audit records matches the model the provider
+    /// actually uses).
     pub fn from_env() -> Self {
         let enabled = std::env::var("DKOD_CODE_REVIEW").map(|v| v == "1").unwrap_or(false);
         // Treat empty-string env vars as absent so that e.g.
@@ -371,9 +374,13 @@ fn provider_error_finding(err_msg: String) -> Finding {
 /// the MCP gate uses the same OpenRouter-over-Anthropic precedence as the
 /// generator-side review step. Returns `None` when no provider key is set.
 ///
-/// `_cfg` is accepted for future use (provider-specific options like the model
-/// override) but is currently unused — the provider reads its config from the
-/// environment directly.
+/// `_cfg.model` is NOT forwarded as a constructor argument — the provider
+/// reads `DKOD_REVIEW_MODEL` directly from the environment (see
+/// `openrouter::from_env` and `claude::ClaudeReviewProvider::new` in
+/// `dk-runner`). Because both paths read the same env var, the model name
+/// recorded in `RecordReviewRequest.model` / `ReviewSnapshot.model` matches
+/// the model the provider actually used. `_cfg` is accepted for future use
+/// (provider-specific options that need programmatic override).
 fn select_provider(_cfg: &GateConfig) -> Option<Box<dyn ReviewProvider>> {
     dk_runner::steps::agent_review::select_provider_from_env()
 }

--- a/crates/dk-mcp/src/review_gate.rs
+++ b/crates/dk-mcp/src/review_gate.rs
@@ -1,19 +1,55 @@
+//! Environment-derived configuration for the MCP code-review gate.
+//!
+//! The gate is an opt-in deep code review that runs before `dk_approve` merges
+//! a changeset, to catch regressions the generator's local review missed. This
+//! module parses the seven `DKOD_*` environment variables into a single
+//! [`GateConfig`] value that the server consults at request time.
+//!
+//! See `docs/plans/2026-04-16-mcp-code-review-gate-design.md` for the broader
+//! design, the gate wiring into `server.rs`, and the review-provider contract.
+
 use std::time::Duration;
 
+/// Effective gate settings derived from the environment at a point in time.
 #[derive(Debug, Clone)]
 pub struct GateConfig {
+    /// `true` when `DKOD_CODE_REVIEW=1` — the gate is requested for this process.
     pub enabled: bool,
-    pub provider_name: Option<String>,    // None if flag set but no key
+    /// Name of the selected provider (`"anthropic"` or `"openrouter"`), or
+    /// `None` if no provider key is set in the environment.
+    pub provider_name: Option<String>,
+    /// Minimum review score (1..=5) a changeset must achieve to pass the gate.
+    /// Defaults to 4. Out-of-range or unparseable values fall back to the default.
     pub min_score: i32,
+    /// Maximum time allowed for a single review call before the backoff policy
+    /// takes over. Defaults to 180 seconds.
     pub timeout: Duration,
+    /// How provider errors and timeouts are handled — see [`BackoffPolicy`].
     pub backoff_policy: BackoffPolicy,
+    /// Optional provider-specific model override (e.g. `anthropic/claude-sonnet-4-5`).
+    /// When `None`, the provider implementation picks its default model.
     pub model: Option<String>,
 }
 
+/// How the gate reacts when the remote review provider errors or times out.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BackoffPolicy { Strict, Degraded }
+pub enum BackoffPolicy {
+    /// Provider errors are recorded as score=None and reject on approve.
+    Strict,
+    /// Falls back to local review silently on provider error.
+    Degraded,
+}
 
 impl GateConfig {
+    /// Parse the gate configuration from the current process environment.
+    ///
+    /// Reads seven variables: `DKOD_CODE_REVIEW` (enable flag; only `"1"` enables),
+    /// `DKOD_OPENROUTER_API_KEY` and `DKOD_ANTHROPIC_API_KEY` (provider selection —
+    /// OpenRouter wins when both are set), `DKOD_REVIEW_MIN_SCORE` (default 4,
+    /// valid 1..=5), `DKOD_REVIEW_TIMEOUT_SECS` (default 180),
+    /// `DKOD_REVIEW_BACKOFF_POLICY` (`"degraded"` selects [`BackoffPolicy::Degraded`];
+    /// anything else — including unset — is [`BackoffPolicy::Strict`]), and
+    /// `DKOD_REVIEW_MODEL` (optional model override, forwarded to the provider).
     pub fn from_env() -> Self {
         let enabled = std::env::var("DKOD_CODE_REVIEW").map(|v| v == "1").unwrap_or(false);
         let provider_name = if std::env::var("DKOD_OPENROUTER_API_KEY").is_ok() {
@@ -39,6 +75,8 @@ impl GateConfig {
         Self { enabled, provider_name, min_score, timeout, backoff_policy, model }
     }
 
+    /// Returns `true` when the gate flag is enabled but no provider key is set —
+    /// the caller should fail closed.
     pub fn misconfigured(&self) -> bool {
         self.enabled && self.provider_name.is_none()
     }

--- a/crates/dk-mcp/src/review_gate.rs
+++ b/crates/dk-mcp/src/review_gate.rs
@@ -10,7 +10,9 @@
 
 use std::time::Duration;
 
-use dk_runner::steps::agent_review::provider::ReviewVerdict;
+use dk_runner::steps::agent_review::provider::{
+    FileContext, ReviewProvider, ReviewRequest, ReviewResponse, ReviewVerdict,
+};
 use dk_runner::findings::{Finding, Severity};
 
 /// Map a review verdict + findings list to a 1–5 integer score.
@@ -101,6 +103,194 @@ impl GateConfig {
     /// the caller should fail closed.
     pub fn misconfigured(&self) -> bool {
         self.enabled && self.provider_name.is_none()
+    }
+}
+
+/// Map a [`Finding`] into the wire-level [`ReviewFindingProto`] used by the
+/// `RecordReview` RPC. Generates a fresh UUID for the `id` field because
+/// [`Finding`] is an in-memory type without a stable identifier.
+fn finding_to_proto(finding: &Finding) -> crate::ReviewFindingProto {
+    crate::ReviewFindingProto {
+        id: uuid::Uuid::new_v4().to_string(),
+        file_path: finding.file_path.clone().unwrap_or_default(),
+        line_start: finding.line.map(|l| l as i32),
+        line_end: None,
+        severity: finding.severity.as_str().to_string(),
+        category: finding.check_name.clone(),
+        message: finding.message.clone(),
+        suggestion: None,
+        confidence: 0.0,
+        dismissed: false,
+    }
+}
+
+/// Construct a synthetic [`Finding`] describing a provider error (HTTP 5xx,
+/// timeout, parse failure). Used by [`build_record_review_request`] under the
+/// [`BackoffPolicy::Strict`] policy so the gate can record score=None with a
+/// human-readable explanation of the failure.
+fn provider_error_finding(err_msg: String) -> Finding {
+    Finding {
+        severity: Severity::Error,
+        check_name: "provider_error".to_string(),
+        message: err_msg,
+        file_path: None,
+        line: None,
+        symbol: None,
+    }
+}
+
+/// Select a [`ReviewProvider`] for the deep-review background task.
+///
+/// Delegates to `dk_runner::steps::agent_review::select_provider_from_env` so
+/// the MCP gate uses the same OpenRouter-over-Anthropic precedence as the
+/// generator-side review step. Returns `None` when no provider key is set.
+///
+/// `_cfg` is accepted for future use (provider-specific options like the model
+/// override) but is currently unused — the provider reads its config from the
+/// environment directly.
+fn select_provider(_cfg: &GateConfig) -> Option<Box<dyn ReviewProvider>> {
+    dk_runner::steps::agent_review::select_provider_from_env()
+}
+
+/// Connect to the dkod gRPC server with the given bearer token. Returns `None`
+/// when no token is available (the server requires authenticated calls) or
+/// when the dial fails — the background review task swallows the error
+/// silently.
+async fn connect_grpc(
+    grpc_addr: String,
+    auth_token: Option<String>,
+) -> Option<crate::grpc::AuthenticatedClient> {
+    let token = auth_token?;
+    match crate::grpc::connect_with_auth(&grpc_addr, token).await {
+        Ok(c) => Some(c),
+        Err(err) => {
+            tracing::debug!(error = %err, addr = %grpc_addr, "background review: gRPC connect failed");
+            None
+        }
+    }
+}
+
+/// Build the `RecordReview` wire message from the provider call result.
+///
+/// Pure helper extracted so it can be unit-tested without spawning tasks or
+/// opening a gRPC channel.
+///
+/// Returns:
+/// - `Some(req)` when the provider succeeded (score set from verdict+findings).
+/// - `Some(req)` with `score: None` when the provider errored AND the config
+///   uses [`BackoffPolicy::Strict`] — the gate records the failure explicitly.
+/// - `None` when the provider errored under [`BackoffPolicy::Degraded`] — the
+///   gate falls back silently and does not record a deep review.
+pub fn build_record_review_request(
+    result: Result<ReviewResponse, anyhow::Error>,
+    elapsed: Duration,
+    session_id: &str,
+    changeset_id: &str,
+    provider_name: &str,
+    cfg: &GateConfig,
+) -> Option<crate::RecordReviewRequest> {
+    match result {
+        Ok(resp) => {
+            let score = score_from_verdict(&resp.verdict, &resp.findings);
+            let findings = resp.findings.iter().map(finding_to_proto).collect();
+            Some(crate::RecordReviewRequest {
+                session_id: session_id.to_string(),
+                changeset_id: changeset_id.to_string(),
+                tier: "deep".to_string(),
+                score: Some(score),
+                summary: Some(resp.summary),
+                findings,
+                provider: provider_name.to_string(),
+                model: cfg.model.clone().unwrap_or_default(),
+                duration_ms: elapsed.as_millis() as i64,
+            })
+        }
+        Err(err) => match cfg.backoff_policy {
+            BackoffPolicy::Strict => {
+                let finding = provider_error_finding(err.to_string());
+                let findings = vec![finding_to_proto(&finding)];
+                Some(crate::RecordReviewRequest {
+                    session_id: session_id.to_string(),
+                    changeset_id: changeset_id.to_string(),
+                    tier: "deep".to_string(),
+                    score: None,
+                    summary: Some(format!("provider error: {err}")),
+                    findings,
+                    provider: provider_name.to_string(),
+                    model: cfg.model.clone().unwrap_or_default(),
+                    duration_ms: elapsed.as_millis() as i64,
+                })
+            }
+            BackoffPolicy::Degraded => None,
+        },
+    }
+}
+
+/// Run a deep code review in the background and record the result via the
+/// `RecordReview` gRPC. Fire-and-forget — returns silently on every error
+/// path (no provider configured, no auth token, dial failure, RPC failure).
+///
+/// Diff + context are passed as empty for now; the MCP server does not yet
+/// have access to a unified diff without adding new RPCs. The gate design
+/// accepts this tradeoff — the gate mechanism is what matters; the review
+/// can be enriched in a follow-up PR.
+pub async fn run_background_review(
+    grpc_addr: String,
+    auth_token: Option<String>,
+    session_id: String,
+    changeset_id: String,
+    diff: String,
+    context: Vec<FileContext>,
+    cfg: GateConfig,
+) {
+    let provider = match select_provider(&cfg) {
+        Some(p) => p,
+        None => {
+            tracing::debug!("background review: no provider configured");
+            return;
+        }
+    };
+    let provider_name = provider.name().to_string();
+    let start = std::time::Instant::now();
+
+    let review_future = provider.review(ReviewRequest {
+        diff,
+        context,
+        language: "rust".into(),
+        intent: "deep review".into(),
+    });
+
+    let timeout_result = tokio::time::timeout(cfg.timeout, review_future).await;
+    let elapsed = start.elapsed();
+
+    let call_result: Result<ReviewResponse, anyhow::Error> = match timeout_result {
+        Ok(Ok(resp)) => Ok(resp),
+        Ok(Err(e)) => Err(e),
+        Err(_) => Err(anyhow::anyhow!(
+            "deep review timed out after {:?}",
+            cfg.timeout
+        )),
+    };
+
+    let record = match build_record_review_request(
+        call_result,
+        elapsed,
+        &session_id,
+        &changeset_id,
+        &provider_name,
+        &cfg,
+    ) {
+        Some(r) => r,
+        None => return, // degraded policy — fall back silently
+    };
+
+    let mut client = match connect_grpc(grpc_addr, auth_token).await {
+        Some(c) => c,
+        None => return,
+    };
+
+    if let Err(e) = client.record_review(record).await {
+        tracing::debug!(error = %e, "background review: record_review RPC failed");
     }
 }
 
@@ -219,5 +409,131 @@ mod verdict_mapping_tests {
     #[test]
     fn request_changes_with_errors_is_1() {
         assert_eq!(score_from_verdict(&ReviewVerdict::RequestChanges, &[f(Severity::Error)]), 1);
+    }
+}
+
+#[cfg(test)]
+mod run_background_review_tests {
+    use super::*;
+    use dk_runner::findings::{Finding, Severity};
+    use dk_runner::steps::agent_review::provider::{ReviewResponse, ReviewVerdict};
+    use std::time::Duration;
+
+    fn cfg_strict() -> GateConfig {
+        GateConfig {
+            enabled: true,
+            provider_name: Some("anthropic".into()),
+            min_score: 4,
+            timeout: Duration::from_secs(180),
+            backoff_policy: BackoffPolicy::Strict,
+            model: None,
+        }
+    }
+
+    #[test]
+    fn builds_request_with_score_5_on_clean_approve() {
+        let resp = ReviewResponse {
+            summary: "OK".into(),
+            findings: vec![],
+            suggestions: vec![],
+            verdict: ReviewVerdict::Approve,
+        };
+        let req = build_record_review_request(
+            Ok(resp),
+            Duration::from_millis(42),
+            "s1",
+            "c1",
+            "anthropic",
+            &cfg_strict(),
+        )
+        .unwrap();
+        assert_eq!(req.session_id, "s1");
+        assert_eq!(req.changeset_id, "c1");
+        assert_eq!(req.tier, "deep");
+        assert_eq!(req.score, Some(5));
+        assert_eq!(req.provider, "anthropic");
+        assert_eq!(req.duration_ms, 42);
+        assert!(req.findings.is_empty());
+    }
+
+    #[test]
+    fn builds_request_with_score_1_on_request_changes_with_error() {
+        let bad = Finding {
+            severity: Severity::Error,
+            check_name: "x".into(),
+            message: "m".into(),
+            file_path: None,
+            line: None,
+            symbol: None,
+        };
+        let resp = ReviewResponse {
+            summary: "bad".into(),
+            findings: vec![bad],
+            suggestions: vec![],
+            verdict: ReviewVerdict::RequestChanges,
+        };
+        let req = build_record_review_request(
+            Ok(resp),
+            Duration::from_millis(100),
+            "s",
+            "c",
+            "anthropic",
+            &cfg_strict(),
+        )
+        .unwrap();
+        assert_eq!(req.score, Some(1));
+        assert_eq!(req.findings.len(), 1);
+        assert_eq!(req.findings[0].severity, "error");
+    }
+
+    #[test]
+    fn builds_error_record_when_strict_and_provider_errored() {
+        let req = build_record_review_request(
+            Err(anyhow::anyhow!("500 from provider")),
+            Duration::from_millis(10),
+            "s",
+            "c",
+            "anthropic",
+            &cfg_strict(),
+        )
+        .unwrap();
+        assert_eq!(req.score, None);
+        assert_eq!(req.findings.len(), 1);
+        assert_eq!(req.findings[0].severity, "error");
+        assert!(req.findings[0].message.contains("500 from provider"));
+    }
+
+    #[test]
+    fn returns_none_when_degraded_and_provider_errored() {
+        let mut cfg = cfg_strict();
+        cfg.backoff_policy = BackoffPolicy::Degraded;
+        let req = build_record_review_request(
+            Err(anyhow::anyhow!("timeout")),
+            Duration::from_millis(10),
+            "s",
+            "c",
+            "anthropic",
+            &cfg,
+        );
+        assert!(req.is_none());
+    }
+
+    #[test]
+    fn finding_to_proto_maps_severity_case() {
+        let finding = Finding {
+            severity: Severity::Warning,
+            check_name: "cat".into(),
+            message: "msg".into(),
+            file_path: Some("f.rs".into()),
+            line: Some(7),
+            symbol: None,
+        };
+        let p = finding_to_proto(&finding);
+        assert_eq!(p.severity, "warning");
+        assert_eq!(p.file_path, "f.rs");
+        assert_eq!(p.line_start, Some(7));
+        assert_eq!(p.category, "cat");
+        assert_eq!(p.message, "msg");
+        assert!(!p.id.is_empty()); // UUID generated
     }
 }

--- a/crates/dk-mcp/src/review_gate.rs
+++ b/crates/dk-mcp/src/review_gate.rs
@@ -136,7 +136,10 @@ pub fn build_review_snapshot(
             model,
         },
         None => crate::ReviewSnapshot {
-            score: Some(0),
+            // `None` distinguishes "force-approved with no deep review at all"
+            // from `Some(0)` which is reserved for "provider errored mid-review"
+            // under strict backoff policy. Audit consumers rely on this.
+            score: None,
             threshold: Some(cfg.min_score),
             findings_count: 0,
             provider,
@@ -985,7 +988,7 @@ mod review_snapshot_tests {
     #[test]
     fn snapshot_from_none() {
         let s = build_review_snapshot(None, &cfg_with_provider());
-        assert_eq!(s.score, Some(0));
+        assert_eq!(s.score, None);
         assert_eq!(s.threshold, Some(4));
         assert_eq!(s.findings_count, 0);
     }

--- a/crates/dk-mcp/src/review_gate.rs
+++ b/crates/dk-mcp/src/review_gate.rs
@@ -260,6 +260,20 @@ pub fn evaluate_gate(
     }
 }
 
+/// Collect one-line warning messages to emit at MCP startup based on the
+/// effective gate config. Currently yields at most one warning.
+pub fn startup_warnings(cfg: &GateConfig) -> Vec<String> {
+    let mut out = Vec::new();
+    if cfg.misconfigured() {
+        out.push(
+            "[dk-mcp] WARNING: DKOD_CODE_REVIEW=1 but no provider key set. \
+             dk_approve will reject with gate_misconfigured until \
+             DKOD_ANTHROPIC_API_KEY or DKOD_OPENROUTER_API_KEY is set.".to_string()
+        );
+    }
+    out
+}
+
 impl GateConfig {
     /// Parse the gate configuration from the current process environment.
     ///
@@ -948,6 +962,46 @@ mod force_validation_tests {
             panic!("expected TooShort, got {r:?}")
         };
         assert_eq!(n, 12);
+    }
+}
+
+#[cfg(test)]
+mod startup_warnings_tests {
+    use super::*;
+
+    fn cfg(enabled: bool, provider: Option<&str>) -> GateConfig {
+        GateConfig {
+            enabled,
+            provider_name: provider.map(|s| s.to_string()),
+            min_score: 4,
+            timeout: std::time::Duration::from_secs(180),
+            backoff_policy: BackoffPolicy::Strict,
+            model: None,
+        }
+    }
+
+    #[test]
+    fn no_warning_when_disabled() {
+        let w = startup_warnings(&cfg(false, None));
+        assert!(w.is_empty(), "got: {:?}", w);
+    }
+
+    #[test]
+    fn no_warning_when_enabled_with_key() {
+        let w = startup_warnings(&cfg(true, Some("anthropic")));
+        assert!(w.is_empty());
+    }
+
+    #[test]
+    fn warning_when_misconfigured() {
+        let w = startup_warnings(&cfg(true, None));
+        assert_eq!(w.len(), 1);
+        let msg = &w[0];
+        assert!(msg.starts_with("[dk-mcp] WARNING:"));
+        assert!(msg.contains("DKOD_CODE_REVIEW=1"));
+        assert!(msg.contains("DKOD_ANTHROPIC_API_KEY"));
+        assert!(msg.contains("DKOD_OPENROUTER_API_KEY"));
+        assert!(msg.contains("gate_misconfigured"));
     }
 }
 

--- a/crates/dk-mcp/src/review_gate.rs
+++ b/crates/dk-mcp/src/review_gate.rs
@@ -10,6 +10,28 @@
 
 use std::time::Duration;
 
+use dk_runner::steps::agent_review::provider::ReviewVerdict;
+use dk_runner::findings::{Finding, Severity};
+
+/// Map a review verdict + findings list to a 1–5 integer score.
+///
+/// - `Approve` + no findings → 5
+/// - `Approve` + any warning/error → 4
+/// - `Comment` → 3
+/// - `RequestChanges` with only warnings → 2
+/// - `RequestChanges` with any error → 1
+pub fn score_from_verdict(verdict: &ReviewVerdict, findings: &[Finding]) -> i32 {
+    let has_error = findings.iter().any(|f| f.severity == Severity::Error);
+    let has_warning = findings.iter().any(|f| f.severity == Severity::Warning);
+    match (verdict, has_error, has_warning) {
+        (ReviewVerdict::Approve, false, false) => 5,
+        (ReviewVerdict::Approve, _, _) => 4,
+        (ReviewVerdict::Comment, _, _) => 3,
+        (ReviewVerdict::RequestChanges, false, _) => 2,
+        (ReviewVerdict::RequestChanges, true, _) => 1,
+    }
+}
+
 /// Effective gate settings derived from the environment at a point in time.
 #[derive(Debug, Clone)]
 pub struct GateConfig {
@@ -164,5 +186,38 @@ mod env_parsing_tests {
         let cfg = GateConfig::from_env();
         assert_eq!(cfg.min_score, 4);
         clear_all();
+    }
+}
+
+#[cfg(test)]
+mod verdict_mapping_tests {
+    use super::score_from_verdict;
+    use dk_runner::steps::agent_review::provider::ReviewVerdict;
+    use dk_runner::findings::{Finding, Severity};
+
+    fn f(sev: Severity) -> Finding {
+        Finding { severity: sev, check_name: "x".into(), message: "m".into(),
+                  file_path: None, line: None, symbol: None }
+    }
+
+    #[test]
+    fn approve_no_issues_is_5() {
+        assert_eq!(score_from_verdict(&ReviewVerdict::Approve, &[]), 5);
+    }
+    #[test]
+    fn approve_with_warnings_is_4() {
+        assert_eq!(score_from_verdict(&ReviewVerdict::Approve, &[f(Severity::Warning)]), 4);
+    }
+    #[test]
+    fn comment_is_3() {
+        assert_eq!(score_from_verdict(&ReviewVerdict::Comment, &[]), 3);
+    }
+    #[test]
+    fn request_changes_with_only_warnings_is_2() {
+        assert_eq!(score_from_verdict(&ReviewVerdict::RequestChanges, &[f(Severity::Warning)]), 2);
+    }
+    #[test]
+    fn request_changes_with_errors_is_1() {
+        assert_eq!(score_from_verdict(&ReviewVerdict::RequestChanges, &[f(Severity::Error)]), 1);
     }
 }

--- a/crates/dk-mcp/src/review_gate.rs
+++ b/crates/dk-mcp/src/review_gate.rs
@@ -66,8 +66,13 @@ pub enum BackoffPolicy {
 
 /// Outcome of evaluating the deep-review gate for a single `dk_approve` call.
 pub enum GateOutcome {
-    /// Gate disabled or gate passed — proceed to forward approve() to the engine.
+    /// Gate disabled or gate passed without a deep-review summary to report —
+    /// proceed to forward approve() to the engine with no extra prefix.
     Pass,
+    /// Gate passed with a deep-review score. The contained string is a
+    /// one-line human-readable prefix (e.g. `"[\u{2713}] deep review: 5/5 (anthropic).\n"`)
+    /// to prepend to the approve() success text.
+    PassWithPrefix(String),
     /// Reject with a structured JSON payload to send back to the caller.
     Reject(String),
 }
@@ -176,7 +181,11 @@ pub fn evaluate_gate(
             });
             GateOutcome::Reject(body.to_string())
         }
-        Some(_) => GateOutcome::Pass,
+        Some(score) => {
+            let provider = cfg.provider_name.as_deref().unwrap_or("?");
+            let prefix = format!("[\u{2713}] deep review: {score}/5 ({provider}).\n");
+            GateOutcome::PassWithPrefix(prefix)
+        }
     }
 }
 
@@ -642,7 +651,7 @@ mod evaluate_gate_tests {
         let r = deep(Some(4), vec![]);
         assert!(matches!(
             evaluate_gate(&cfg_on(), false, Some(&r)),
-            GateOutcome::Pass
+            GateOutcome::PassWithPrefix(_)
         ));
     }
     #[test]
@@ -650,6 +659,32 @@ mod evaluate_gate_tests {
         let r = deep(Some(5), vec![]);
         assert!(matches!(
             evaluate_gate(&cfg_on(), false, Some(&r)),
+            GateOutcome::PassWithPrefix(_)
+        ));
+    }
+
+    #[test]
+    fn pass_with_prefix_when_above_threshold() {
+        let r = deep(Some(5), vec![]);
+        let GateOutcome::PassWithPrefix(p) = evaluate_gate(&cfg_on(), false, Some(&r)) else {
+            panic!()
+        };
+        assert!(p.contains("deep review: 5/5"));
+        assert!(p.contains("anthropic"));
+    }
+    #[test]
+    fn pass_with_prefix_at_threshold() {
+        let r = deep(Some(4), vec![]);
+        let GateOutcome::PassWithPrefix(p) = evaluate_gate(&cfg_on(), false, Some(&r)) else {
+            panic!()
+        };
+        assert!(p.contains("deep review: 4/5"));
+    }
+    #[test]
+    fn no_prefix_when_gate_disabled() {
+        let r = deep(Some(5), vec![]);
+        assert!(matches!(
+            evaluate_gate(&cfg_off(), false, Some(&r)),
             GateOutcome::Pass
         ));
     }

--- a/crates/dk-mcp/src/review_gate.rs
+++ b/crates/dk-mcp/src/review_gate.rs
@@ -64,6 +64,57 @@ pub enum BackoffPolicy {
     Degraded,
 }
 
+/// Outcome of evaluating the deep-review gate for a single `dk_approve` call.
+pub enum GateOutcome {
+    /// Gate disabled or gate passed — proceed to forward approve() to the engine.
+    Pass,
+    /// Reject with a structured JSON payload to send back to the caller.
+    Reject(String),
+}
+
+/// Evaluate the gate for a `dk_approve` call.
+///
+/// - `!cfg.enabled` → `Pass` (no gate).
+/// - `force` → `Pass` (caller-supplied override; reason validation is handled
+///   in the server layer).
+/// - `cfg.misconfigured()` → `Reject` with a `gate_misconfigured` payload.
+/// - `deep_review` is `None` → `Reject` with a `deep_review_pending` payload
+///   that instructs the caller to retry in ~15 seconds.
+/// - `deep_review` is `Some(_)` → `Pass` (score-based checks are layered on
+///   in later tasks).
+pub fn evaluate_gate(
+    cfg: &GateConfig,
+    force: bool,
+    deep_review: Option<&crate::ReviewResultProto>,
+) -> GateOutcome {
+    if !cfg.enabled {
+        return GateOutcome::Pass;
+    }
+    if force {
+        return GateOutcome::Pass;
+    }
+    if cfg.misconfigured() {
+        let body = serde_json::json!({
+            "error": "gate_misconfigured",
+            "message": "DKOD_CODE_REVIEW=1 but no provider key (DKOD_ANTHROPIC_API_KEY or DKOD_OPENROUTER_API_KEY).",
+        });
+        return GateOutcome::Reject(body.to_string());
+    }
+    if deep_review.is_none() {
+        let body = serde_json::json!({
+            "error": "deep_review_pending",
+            "message": "Deep code review has not completed yet. Retry dk_approve in ~15s, or poll dk_review.",
+            "next_action": {
+                "kind": "wait_and_retry",
+                "retry_after_secs": 15,
+                "can_fix": false,
+            },
+        });
+        return GateOutcome::Reject(body.to_string());
+    }
+    GateOutcome::Pass
+}
+
 impl GateConfig {
     /// Parse the gate configuration from the current process environment.
     ///
@@ -419,6 +470,75 @@ mod verdict_mapping_tests {
     #[test]
     fn request_changes_with_errors_is_1() {
         assert_eq!(score_from_verdict(&ReviewVerdict::RequestChanges, &[f(Severity::Error)]), 1);
+    }
+}
+
+#[cfg(test)]
+mod evaluate_gate_tests {
+    use super::*;
+    use crate::ReviewResultProto;
+
+    fn cfg_off() -> GateConfig {
+        GateConfig {
+            enabled: false,
+            provider_name: None,
+            min_score: 4,
+            timeout: std::time::Duration::from_secs(180),
+            backoff_policy: BackoffPolicy::Strict,
+            model: None,
+        }
+    }
+    fn cfg_on() -> GateConfig {
+        GateConfig {
+            enabled: true,
+            provider_name: Some("anthropic".into()),
+            min_score: 4,
+            timeout: std::time::Duration::from_secs(180),
+            backoff_policy: BackoffPolicy::Strict,
+            model: None,
+        }
+    }
+    fn cfg_misconfigured() -> GateConfig {
+        GateConfig {
+            enabled: true,
+            provider_name: None,
+            min_score: 4,
+            timeout: std::time::Duration::from_secs(180),
+            backoff_policy: BackoffPolicy::Strict,
+            model: None,
+        }
+    }
+
+    #[test]
+    fn pass_when_gate_disabled() {
+        assert!(matches!(
+            evaluate_gate(&cfg_off(), false, None),
+            GateOutcome::Pass
+        ));
+    }
+    #[test]
+    fn pass_when_force_even_if_pending() {
+        assert!(matches!(
+            evaluate_gate(&cfg_on(), true, None),
+            GateOutcome::Pass
+        ));
+    }
+    #[test]
+    fn reject_misconfigured() {
+        let GateOutcome::Reject(body) = evaluate_gate(&cfg_misconfigured(), false, None) else {
+            panic!()
+        };
+        assert!(body.contains("gate_misconfigured"));
+        assert!(body.contains("DKOD_CODE_REVIEW"));
+    }
+    #[test]
+    fn reject_deep_review_pending() {
+        let GateOutcome::Reject(body) = evaluate_gate(&cfg_on(), false, None) else {
+            panic!()
+        };
+        assert!(body.contains("deep_review_pending"));
+        assert!(body.contains("\"retry_after_secs\":15"));
+        assert!(body.contains("\"can_fix\":false"));
     }
 }
 

--- a/crates/dk-mcp/src/review_gate.rs
+++ b/crates/dk-mcp/src/review_gate.rs
@@ -77,6 +77,74 @@ pub enum GateOutcome {
     Reject(String),
 }
 
+/// Outcome of validating an `override_reason` supplied to a force-approve call.
+///
+/// Used by [`validate_override_reason`] to separate the three shapes the
+/// server layer needs to surface distinct error messages for:
+/// absent/empty, present-but-too-short, and well-formed.
+#[derive(Debug)]
+pub enum OverrideReasonValidation {
+    /// Trimmed reason is at least 20 characters — carries the trimmed string
+    /// ready to forward to the engine.
+    Ok(String),
+    /// Reason is `None`, empty, or all-whitespace.
+    Empty,
+    /// Reason is present but trimmed character count is `< 20`; carries the
+    /// actual length so the error can include it in the diagnostic.
+    TooShort(usize),
+}
+
+/// Validate the `override_reason` supplied to a force-approve call.
+///
+/// Trims leading/trailing whitespace and counts the remaining Unicode scalar
+/// values (not bytes) to enforce the 20-character minimum. Unicode-aware so
+/// that, e.g., `"🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀"` is rejected as 12 chars, not
+/// accepted as ~48 bytes.
+pub fn validate_override_reason(reason: Option<&str>) -> OverrideReasonValidation {
+    let trimmed = reason.unwrap_or("").trim();
+    if trimmed.is_empty() {
+        return OverrideReasonValidation::Empty;
+    }
+    let len = trimmed.chars().count();
+    if len < 20 {
+        return OverrideReasonValidation::TooShort(len);
+    }
+    OverrideReasonValidation::Ok(trimmed.to_string())
+}
+
+/// Build a [`crate::ReviewSnapshot`] from the current deep review (if any) and
+/// gate config, capturing an audit record of the review state at the moment
+/// `dk_approve(force: true)` was called.
+///
+/// When no deep review exists (provider not yet finished, background spawn
+/// failed, etc.) the snapshot records `score = Some(0)`, `findings_count = 0`,
+/// and the configured threshold so the audit row is still self-describing.
+/// The `provider` and `model` fields are taken from [`GateConfig`] rather than
+/// the review result because the review result has no provider field.
+pub fn build_review_snapshot(
+    deep_review: Option<&crate::ReviewResultProto>,
+    cfg: &GateConfig,
+) -> crate::ReviewSnapshot {
+    let provider = cfg.provider_name.clone().unwrap_or_default();
+    let model = cfg.model.clone().unwrap_or_default();
+    match deep_review {
+        Some(r) => crate::ReviewSnapshot {
+            score: Some(r.score.unwrap_or(0)),
+            threshold: Some(cfg.min_score),
+            findings_count: r.findings.len() as u32,
+            provider,
+            model,
+        },
+        None => crate::ReviewSnapshot {
+            score: Some(0),
+            threshold: Some(cfg.min_score),
+            findings_count: 0,
+            provider,
+            model,
+        },
+    }
+}
+
 /// Serializable projection of [`crate::ReviewFindingProto`] for embedding in
 /// gate rejection payloads. prost-generated types do not derive `Serialize`,
 /// so we hand-copy the fields we want to surface.
@@ -813,5 +881,112 @@ mod run_background_review_tests {
         assert_eq!(p.category, "cat");
         assert_eq!(p.message, "msg");
         assert!(!p.id.is_empty()); // UUID generated
+    }
+}
+
+#[cfg(test)]
+mod force_validation_tests {
+    use super::{validate_override_reason, OverrideReasonValidation};
+
+    #[test]
+    fn empty_is_rejected() {
+        assert!(matches!(
+            validate_override_reason(None),
+            OverrideReasonValidation::Empty
+        ));
+        assert!(matches!(
+            validate_override_reason(Some("")),
+            OverrideReasonValidation::Empty
+        ));
+        assert!(matches!(
+            validate_override_reason(Some("   \t\n  ")),
+            OverrideReasonValidation::Empty
+        ));
+    }
+
+    #[test]
+    fn short_is_rejected_with_length() {
+        let r = validate_override_reason(Some("five"));
+        let OverrideReasonValidation::TooShort(n) = r else {
+            panic!("expected TooShort, got {r:?}")
+        };
+        assert_eq!(n, 4);
+    }
+
+    #[test]
+    fn exactly_20_chars_ok() {
+        // exactly 20 chars
+        let twenty = "abcdefghijklmnopqrst";
+        assert_eq!(twenty.chars().count(), 20);
+        let OverrideReasonValidation::Ok(s) = validate_override_reason(Some(twenty)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(s, twenty);
+    }
+
+    #[test]
+    fn whitespace_trimmed_before_count() {
+        let padded = "   API wedged for 20 minutes; reviewed manually in chat   ";
+        let OverrideReasonValidation::Ok(s) = validate_override_reason(Some(padded)) else {
+            panic!("expected Ok");
+        };
+        assert!(!s.starts_with(' '));
+        assert!(!s.ends_with(' '));
+        assert!(s.chars().count() >= 20);
+    }
+
+    #[test]
+    fn unicode_counted_by_char_not_byte() {
+        // 12 emojis = 12 chars but ~48 bytes — must be rejected.
+        let emojis = "🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀";
+        assert_eq!(emojis.chars().count(), 12);
+        let r = validate_override_reason(Some(emojis));
+        let OverrideReasonValidation::TooShort(n) = r else {
+            panic!("expected TooShort, got {r:?}")
+        };
+        assert_eq!(n, 12);
+    }
+}
+
+#[cfg(test)]
+mod review_snapshot_tests {
+    use super::*;
+    use crate::{ReviewFindingProto, ReviewResultProto};
+
+    fn cfg_with_provider() -> GateConfig {
+        GateConfig {
+            enabled: true,
+            provider_name: Some("anthropic".into()),
+            min_score: 4,
+            timeout: std::time::Duration::from_secs(180),
+            backoff_policy: BackoffPolicy::Strict,
+            model: Some("claude-sonnet-4-6".into()),
+        }
+    }
+
+    #[test]
+    fn snapshot_from_deep_review() {
+        let r = ReviewResultProto {
+            id: "r".into(),
+            tier: "deep".into(),
+            score: Some(2),
+            summary: None,
+            findings: vec![ReviewFindingProto::default(); 3],
+            created_at: "".into(),
+        };
+        let s = build_review_snapshot(Some(&r), &cfg_with_provider());
+        assert_eq!(s.score, Some(2));
+        assert_eq!(s.threshold, Some(4));
+        assert_eq!(s.findings_count, 3);
+        assert_eq!(s.provider, "anthropic");
+        assert_eq!(s.model, "claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn snapshot_from_none() {
+        let s = build_review_snapshot(None, &cfg_with_provider());
+        assert_eq!(s.score, Some(0));
+        assert_eq!(s.threshold, Some(4));
+        assert_eq!(s.findings_count, 0);
     }
 }

--- a/crates/dk-mcp/src/review_gate_mock.rs
+++ b/crates/dk-mcp/src/review_gate_mock.rs
@@ -1,0 +1,50 @@
+//! Mock `ReviewProvider` for use in unit and integration tests. This module is
+//! gated behind `#[cfg(any(test, feature = "mock-review"))]` so it never
+//! contributes to a production build unless the `mock-review` feature is
+//! explicitly enabled by a test binary.
+
+use async_trait::async_trait;
+use anyhow::Result;
+use dk_runner::steps::agent_review::provider::{ReviewProvider, ReviewRequest, ReviewResponse, ReviewVerdict};
+use dk_runner::findings::{Finding, Suggestion};
+
+/// Fixed-response `ReviewProvider` used by tests. Always returns the
+/// `verdict` and `findings` supplied at construction time.
+pub struct MockReviewProvider {
+    verdict: ReviewVerdict,
+    findings: Vec<Finding>,
+}
+
+impl MockReviewProvider {
+    pub fn new(verdict: ReviewVerdict, findings: Vec<Finding>) -> Self {
+        Self { verdict, findings }
+    }
+}
+
+#[async_trait]
+impl ReviewProvider for MockReviewProvider {
+    fn name(&self) -> &str { "mock" }
+    async fn review(&self, _req: ReviewRequest) -> Result<ReviewResponse> {
+        Ok(ReviewResponse {
+            summary: "mock".into(),
+            findings: self.findings.clone(),
+            suggestions: Vec::<Suggestion>::new(),
+            verdict: self.verdict.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MockReviewProvider;
+    use dk_runner::steps::agent_review::provider::{ReviewProvider, ReviewRequest, ReviewVerdict};
+
+    #[tokio::test]
+    async fn mock_returns_configured_score() {
+        let m = MockReviewProvider::new(ReviewVerdict::Approve, vec![]);
+        let resp = m.review(ReviewRequest {
+            diff: "".into(), context: vec![], language: "rust".into(), intent: "t".into()
+        }).await.unwrap();
+        assert!(matches!(resp.verdict, ReviewVerdict::Approve));
+    }
+}

--- a/crates/dk-mcp/src/server.rs
+++ b/crates/dk-mcp/src/server.rs
@@ -1755,7 +1755,13 @@ impl DkodMcp {
                     )
                     .await;
                 });
-                self.review_tasks.lock().await.push(handle);
+                {
+                    let mut tasks = self.review_tasks.lock().await;
+                    // Prune completed handles before adding a new one to bound
+                    // Vec growth for long-lived sessions.
+                    tasks.retain(|h| !h.is_finished());
+                    tasks.push(handle);
+                }
                 text.push_str(&format!(
                     "\nDeep code review started in background (provider: {}, min_score: {}). Retry dk_approve to check status.\n",
                     cfg.provider_name.as_deref().unwrap_or("?"),

--- a/crates/dk-mcp/src/server.rs
+++ b/crates/dk-mcp/src/server.rs
@@ -255,6 +255,11 @@ pub struct DkodMcp {
     /// Per-session notification for blocking dk_watch. Signaled when new events
     /// are buffered so a waiting dk_watch call can wake up immediately.
     watch_notify: Arc<Mutex<HashMap<String, Arc<tokio::sync::Notify>>>>,
+    /// Per-submit background review task handles.
+    /// Populated each time `dk_submit` spawns a deep-review task when the
+    /// code review gate is enabled. Cleared on `Drop` so closing the MCP
+    /// instance aborts in-flight provider HTTP calls.
+    review_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
 }
 
 /// Cancel all per-session NATS and Watch tasks when the MCP instance drops
@@ -293,6 +298,13 @@ impl Drop for DkodMcp {
             }
             notifiers.clear();
         }
+        // Abort all pending review background tasks so closing the MCP
+        // doesn't leak outstanding provider HTTP calls.
+        if let Ok(mut tasks) = self.review_tasks.try_lock() {
+            for handle in tasks.drain(..) {
+                handle.abort();
+            }
+        }
     }
 }
 
@@ -317,6 +329,7 @@ impl DkodMcp {
             my_modified_symbols: Arc::new(Mutex::new(HashMap::new())),
             watch_overflow: Arc::new(Mutex::new(HashMap::new())),
             watch_notify: Arc::new(Mutex::new(HashMap::new())),
+            review_tasks: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -350,6 +363,7 @@ impl DkodMcp {
             my_modified_symbols: Arc::new(Mutex::new(HashMap::new())),
             watch_overflow: Arc::new(Mutex::new(HashMap::new())),
             watch_notify: Arc::new(Mutex::new(HashMap::new())),
+            review_tasks: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -400,6 +414,7 @@ impl DkodMcp {
             my_modified_symbols: Arc::new(Mutex::new(HashMap::new())),
             watch_overflow: Arc::new(Mutex::new(HashMap::new())),
             watch_notify: Arc::new(Mutex::new(HashMap::new())),
+            review_tasks: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -422,6 +437,7 @@ impl DkodMcp {
             my_modified_symbols: Arc::new(Mutex::new(HashMap::new())),
             watch_overflow: Arc::new(Mutex::new(HashMap::new())),
             watch_notify: Arc::new(Mutex::new(HashMap::new())),
+            review_tasks: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -1718,7 +1734,7 @@ impl DkodMcp {
                 let session_id_clone = session_id.clone();
                 let changeset_id = response.changeset_id.clone();
                 let cfg_clone = cfg.clone();
-                tokio::spawn(async move {
+                let handle = tokio::spawn(async move {
                     crate::review_gate::run_background_review(
                         grpc_addr,
                         auth_token,
@@ -1730,6 +1746,7 @@ impl DkodMcp {
                     )
                     .await;
                 });
+                self.review_tasks.lock().await.push(handle);
                 text.push_str(&format!(
                     "\nDeep code review started in background (provider: {}, min_score: {}). Retry dk_approve to check status.\n",
                     cfg.provider_name.as_deref().unwrap_or("?"),

--- a/crates/dk-mcp/src/server.rs
+++ b/crates/dk-mcp/src/server.rs
@@ -2365,8 +2365,52 @@ impl DkodMcp {
 
         let session = self.resolve_session(param_session_id.as_deref()).await?;
         let session_id = session.session_id.clone();
+        let changeset_id = session.changeset_id.clone();
 
         let mut client = self.get_client().await?;
+
+        // Deep-review gate (opt-in via DKOD_CODE_REVIEW=1). When enabled, fetch
+        // the recorded reviews for this changeset and consult the pure
+        // `evaluate_gate` helper. A `Reject` short-circuits with a structured
+        // JSON body that tells the caller how to proceed (retry, fix, or
+        // override via `force`).
+        let cfg = crate::review_gate::GateConfig::from_env();
+        if cfg.enabled {
+            // Task 2.8 will add a `force` param; for now always false.
+            let force = false;
+            // `misconfigured` is decided inside `evaluate_gate`, but we skip
+            // the Review RPC when we already know the gate will reject — no
+            // point paying for a network round trip.
+            let deep_review_owned = if cfg.misconfigured() {
+                None
+            } else {
+                let review_req = crate::ReviewRequest {
+                    session_id: session_id.clone(),
+                    changeset_id: changeset_id.clone(),
+                };
+                let review_resp = client.review(review_req).await.map_err(|e| {
+                    McpError::internal_error(format!("REVIEW RPC failed: {e}"), None)
+                })?;
+                review_resp
+                    .into_inner()
+                    .reviews
+                    .into_iter()
+                    .find(|r| r.tier == "deep")
+            };
+
+            match crate::review_gate::evaluate_gate(&cfg, force, deep_review_owned.as_ref()) {
+                crate::review_gate::GateOutcome::Pass => { /* fall through to approve */ }
+                crate::review_gate::GateOutcome::Reject(body) => {
+                    let prefix = self
+                        .drain_notifications(&session_id)
+                        .await
+                        .unwrap_or_default();
+                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                        "{prefix}{body}"
+                    ))]));
+                }
+            }
+        }
 
         let request = crate::ApproveRequest {
             session_id: session_id.clone(),

--- a/crates/dk-mcp/src/server.rs
+++ b/crates/dk-mcp/src/server.rs
@@ -2453,6 +2453,16 @@ impl DkodMcp {
             ))]));
         }
 
+        // `force: true` with the gate disabled is a no-op: we log the intent
+        // once to stderr and fall through to the normal approve path, which
+        // sends `override_reason: None, review_snapshot: None` to the engine
+        // and produces the standard success text (no `force-approved` marker).
+        if force && !cfg.enabled {
+            tracing::info!(
+                "force requested but gate is disabled — proceeding as normal approve"
+            );
+        }
+
         // Deep-review gate (opt-in via DKOD_CODE_REVIEW=1). When enabled, fetch
         // the recorded reviews for this changeset and consult the pure
         // `evaluate_gate` helper. A `Reject` short-circuits with a structured

--- a/crates/dk-mcp/src/server.rs
+++ b/crates/dk-mcp/src/server.rs
@@ -1697,6 +1697,47 @@ impl DkodMcp {
             }
         }
 
+        // Background deep review gate: spawn an async task to call the
+        // configured review provider (Anthropic/OpenRouter), then record the
+        // result via RecordReview so dk_approve can gate on its score.
+        // Only runs on a successful submit (Accepted). Fire-and-forget — any
+        // failure (no provider, gRPC dial failure, provider timeout) is
+        // swallowed, and dk_approve will see "no deep review recorded yet".
+        //
+        // TODO: diff + file context are passed empty for now; enriching them
+        // would require either a new GetChangesetDiff RPC or a FileList+
+        // FileRead loop. Deferred to a follow-up PR — the gate mechanism is
+        // the primary value of this change.
+        if response.status == crate::SubmitStatus::Accepted as i32 {
+            let cfg = crate::review_gate::GateConfig::from_env();
+            if cfg.enabled && !cfg.misconfigured() {
+                let (grpc_addr, auth_token) = {
+                    let conn = self.connection.read().await;
+                    (conn.server_addr.clone(), conn.auth_token.clone())
+                };
+                let session_id_clone = session_id.clone();
+                let changeset_id = response.changeset_id.clone();
+                let cfg_clone = cfg.clone();
+                tokio::spawn(async move {
+                    crate::review_gate::run_background_review(
+                        grpc_addr,
+                        auth_token,
+                        session_id_clone,
+                        changeset_id,
+                        String::new(),
+                        Vec::new(),
+                        cfg_clone,
+                    )
+                    .await;
+                });
+                text.push_str(&format!(
+                    "\nDeep code review started in background (provider: {}, min_score: {}). Retry dk_approve to check status.\n",
+                    cfg.provider_name.as_deref().unwrap_or("?"),
+                    cfg.min_score
+                ));
+            }
+        }
+
         let prefix = self
             .drain_notifications(&session_id)
             .await

--- a/crates/dk-mcp/src/server.rs
+++ b/crates/dk-mcp/src/server.rs
@@ -1740,33 +1740,46 @@ impl DkodMcp {
                     let conn = self.connection.read().await;
                     (conn.server_addr.clone(), conn.auth_token.clone())
                 };
-                let session_id_clone = session_id.clone();
-                let changeset_id = response.changeset_id.clone();
-                let cfg_clone = cfg.clone();
-                let handle = tokio::spawn(async move {
-                    crate::review_gate::run_background_review(
-                        grpc_addr,
-                        auth_token,
-                        session_id_clone,
-                        changeset_id,
-                        String::new(),
-                        Vec::new(),
-                        cfg_clone,
-                    )
-                    .await;
-                });
-                {
-                    let mut tasks = self.review_tasks.lock().await;
-                    // Prune completed handles before adding a new one to bound
-                    // Vec growth for long-lived sessions.
-                    tasks.retain(|h| !h.is_finished());
-                    tasks.push(handle);
+                // Background review uses `conn.auth_token`, which is sourced
+                // from env var or dotenv — device-flow tokens cached to disk
+                // are not read back into `conn` (see SessionState::resolve).
+                // Without a token, `connect_grpc` returns `None` and the
+                // background task exits silently; `dk_approve` would then
+                // loop on `deep_review_pending`. Surface this explicitly so
+                // the user is not misled by a "review started" message.
+                if auth_token.is_none() {
+                    text.push_str(
+                        "\nDeep code review gate enabled but no DKOD_AUTH_TOKEN is                          available to the background task (device-flow tokens are not                          yet re-exposed to `dk_submit`). The background review will                          not run — set DKOD_AUTH_TOKEN in the env or dotenv, or use                          `dk_approve(force: true, override_reason: ...)` to bypass.\n"
+                    );
+                } else {
+                    let session_id_clone = session_id.clone();
+                    let changeset_id = response.changeset_id.clone();
+                    let cfg_clone = cfg.clone();
+                    let handle = tokio::spawn(async move {
+                        crate::review_gate::run_background_review(
+                            grpc_addr,
+                            auth_token,
+                            session_id_clone,
+                            changeset_id,
+                            String::new(),
+                            Vec::new(),
+                            cfg_clone,
+                        )
+                        .await;
+                    });
+                    {
+                        let mut tasks = self.review_tasks.lock().await;
+                        // Prune completed handles before adding a new one to bound
+                        // Vec growth for long-lived sessions.
+                        tasks.retain(|h| !h.is_finished());
+                        tasks.push(handle);
+                    }
+                    text.push_str(&format!(
+                        "\nDeep code review started in background (provider: {}, min_score: {}). Retry dk_approve to check status.\n",
+                        cfg.provider_name.as_deref().unwrap_or("?"),
+                        cfg.min_score
+                    ));
                 }
-                text.push_str(&format!(
-                    "\nDeep code review started in background (provider: {}, min_score: {}). Retry dk_approve to check status.\n",
-                    cfg.provider_name.as_deref().unwrap_or("?"),
-                    cfg.min_score
-                ));
             }
         }
 

--- a/crates/dk-mcp/src/server.rs
+++ b/crates/dk-mcp/src/server.rs
@@ -2373,8 +2373,10 @@ impl DkodMcp {
         // the recorded reviews for this changeset and consult the pure
         // `evaluate_gate` helper. A `Reject` short-circuits with a structured
         // JSON body that tells the caller how to proceed (retry, fix, or
-        // override via `force`).
+        // override via `force`). `PassWithPrefix` contains a human-readable
+        // one-liner that gets prepended to the approval success text.
         let cfg = crate::review_gate::GateConfig::from_env();
+        let mut gate_prefix = String::new();
         if cfg.enabled {
             // Task 2.8 will add a `force` param; for now always false.
             let force = false;
@@ -2400,6 +2402,9 @@ impl DkodMcp {
 
             match crate::review_gate::evaluate_gate(&cfg, force, deep_review_owned.as_ref()) {
                 crate::review_gate::GateOutcome::Pass => { /* fall through to approve */ }
+                crate::review_gate::GateOutcome::PassWithPrefix(p) => {
+                    gate_prefix = p;
+                }
                 crate::review_gate::GateOutcome::Reject(body) => {
                     let prefix = self
                         .drain_notifications(&session_id)
@@ -2425,7 +2430,7 @@ impl DkodMcp {
             .into_inner();
 
         let text = format!(
-            "Changeset approved!\nchangeset_id: {}\nstate: {}\n\nThe changeset is now approved and ready for dk_merge.\n",
+            "{gate_prefix}Changeset approved!\nchangeset_id: {}\nstate: {}\n\nThe changeset is now approved and ready for dk_merge.\n",
             response.changeset_id, response.new_state
         );
 

--- a/crates/dk-mcp/src/server.rs
+++ b/crates/dk-mcp/src/server.rs
@@ -150,6 +150,15 @@ struct MergeParams {
 struct ApproveParams {
     /// Session ID from dk_connect (required when multiple sessions are active)
     session_id: Option<String>,
+    /// Bypass the deep-review gate. Requires `override_reason` ≥20 chars and
+    /// stamps an audit snapshot on the approve record. No-op when
+    /// DKOD_CODE_REVIEW is unset.
+    #[serde(default)]
+    force: Option<bool>,
+    /// Human-readable reason for bypassing the review gate. Required and
+    /// ≥20 characters when `force: true` and the gate is enabled.
+    #[serde(default)]
+    override_reason: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -2353,7 +2362,7 @@ impl DkodMcp {
 
     /// Approve a changeset via gRPC.
     #[tool(
-        description = "Approve a submitted changeset for the current session. Call after dk_submit and before dk_merge."
+        description = "Approve a submitted changeset for the current session. Call after dk_submit and before dk_merge. Pass `force: true` with an `override_reason` (≥20 chars) to bypass the deep-review gate when enabled."
     )]
     async fn dk_approve(
         &self,
@@ -2361,7 +2370,10 @@ impl DkodMcp {
     ) -> Result<CallToolResult, McpError> {
         let ApproveParams {
             session_id: param_session_id,
+            force,
+            override_reason,
         } = params;
+        let force = force.unwrap_or(false);
 
         let session = self.resolve_session(param_session_id.as_deref()).await?;
         let session_id = session.session_id.clone();
@@ -2369,17 +2381,86 @@ impl DkodMcp {
 
         let mut client = self.get_client().await?;
 
+        let cfg = crate::review_gate::GateConfig::from_env();
+
+        // Force path: when `force: true` AND the gate is enabled, validate the
+        // override_reason, snapshot the current review state for the audit
+        // trail, and forward a force-approve request that bypasses the score
+        // check on the engine side. The success text carries a `⚠ force-approved`
+        // marker so downstream agents can see the bypass happened.
+        if force && cfg.enabled {
+            use crate::review_gate::OverrideReasonValidation as V;
+            let reason = match crate::review_gate::validate_override_reason(
+                override_reason.as_deref(),
+            ) {
+                V::Ok(r) => r,
+                V::Empty => {
+                    return Ok(CallToolResult::error(vec![Content::text(
+                        "force requires override_reason (non-empty)".to_string(),
+                    )]));
+                }
+                V::TooShort(n) => {
+                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                        "override_reason must be at least 20 characters (describe why review is being bypassed) — got {n}"
+                    ))]));
+                }
+            };
+
+            // Snapshot the current deep-review state for the audit record.
+            // Skip the Review RPC if the gate is misconfigured — we still
+            // force-approve, but the snapshot will reflect "no review seen".
+            let deep_review_for_snapshot = if cfg.misconfigured() {
+                None
+            } else {
+                let review_req = crate::ReviewRequest {
+                    session_id: session_id.clone(),
+                    changeset_id: changeset_id.clone(),
+                };
+                let review_resp = client.review(review_req).await.map_err(|e| {
+                    McpError::internal_error(format!("REVIEW RPC failed: {e}"), None)
+                })?;
+                review_resp
+                    .into_inner()
+                    .reviews
+                    .into_iter()
+                    .find(|r| r.tier == "deep")
+            };
+            let snap = crate::review_gate::build_review_snapshot(
+                deep_review_for_snapshot.as_ref(),
+                &cfg,
+            );
+
+            let request = crate::ApproveRequest {
+                session_id: session_id.clone(),
+                override_reason: Some(reason.clone()),
+                review_snapshot: Some(snap),
+            };
+            let response = client
+                .approve(request)
+                .await
+                .map_err(|e| McpError::internal_error(format!("APPROVE RPC failed: {e}"), None))?
+                .into_inner();
+            let text = format!(
+                "Changeset approved!\nchangeset_id: {}\nstate: {}\n\u{26a0} force-approved: {}\n",
+                response.changeset_id, response.new_state, reason
+            );
+            let prefix = self
+                .drain_notifications(&session_id)
+                .await
+                .unwrap_or_default();
+            return Ok(CallToolResult::success(vec![Content::text(format!(
+                "{prefix}{text}"
+            ))]));
+        }
+
         // Deep-review gate (opt-in via DKOD_CODE_REVIEW=1). When enabled, fetch
         // the recorded reviews for this changeset and consult the pure
         // `evaluate_gate` helper. A `Reject` short-circuits with a structured
         // JSON body that tells the caller how to proceed (retry, fix, or
         // override via `force`). `PassWithPrefix` contains a human-readable
         // one-liner that gets prepended to the approval success text.
-        let cfg = crate::review_gate::GateConfig::from_env();
         let mut gate_prefix = String::new();
         if cfg.enabled {
-            // Task 2.8 will add a `force` param; for now always false.
-            let force = false;
             // `misconfigured` is decided inside `evaluate_gate`, but we skip
             // the Review RPC when we already know the gate will reject — no
             // point paying for a network round trip.


### PR DESCRIPTION
## Summary

Phase 2 of the MCP code review gate — turns on the gate behind the `DKOD_CODE_REVIEW=1` flag. Dormant capability from Phase 1 (PR #69, v0.2.80) and Phase 1b (platform v0.0.270) becomes active.

- **`dk_submit`** spawns a background deep-review task when `DKOD_CODE_REVIEW=1` is set with a provider key (`DKOD_ANTHROPIC_API_KEY` or `DKOD_OPENROUTER_API_KEY` — OpenRouter wins when both).
- **`dk_approve` gate** with four structured rejection paths:
  - `gate_misconfigured` — flag set but no provider key.
  - `deep_review_pending` — review hasn't completed yet; includes `retry_after_secs: 15`.
  - `review_score_below_threshold` — inline findings + `fix_and_resubmit` next_action.
  - `review_provider_error` — provider errored under strict backoff.
- **Force path**: `dk_approve(force: true, override_reason: "...")` bypasses the gate with a ≥20-char reason and stamps a `ReviewSnapshot` audit record on the approve request.
- **Success prefix**: gate-enabled approvals prefix the success text with `[✓] deep review: N/5 (provider).`.
- **Startup warning**: stderr line when `DKOD_CODE_REVIEW=1` is set without a provider key.
- **Lifecycle tracking**: background review tasks stored in `DkodMcp::review_tasks` and aborted in `Drop` to prevent orphan provider HTTP calls on shutdown.
- **Force no-op**: `force: true` with the gate disabled falls through to normal approve and logs at `info`.

Depends on: PR #69 (RecordReview RPC + `ApproveRequest.override_reason`/`review_snapshot` + OpenRouter provider).

Design doc: `docs/plans/2026-04-16-mcp-code-review-gate-design.md` (PR #68 still open).

## Architecture

All new gate logic lives in `crates/dk-mcp/src/review_gate.rs`:

- `GateConfig::from_env()` — parses the seven env vars, defaults and precedence rules.
- `score_from_verdict(verdict, findings) -> i32` — maps Approve/Comment/RequestChanges + severity to 1–5.
- `MockReviewProvider` — feature-gated mock behind `cfg(any(test, feature = "mock-review"))` for unit tests.
- `run_background_review(...)` + pure helpers (`build_record_review_request`, `finding_to_proto`, `provider_error_finding`, `select_provider`, `connect_grpc`).
- `evaluate_gate(cfg, force, Option<deep_review>) -> GateOutcome` — pure decision function. `GateOutcome::{Pass, PassWithPrefix(String), Reject(String)}`.
- `validate_override_reason(Option<&str>) -> OverrideReasonValidation::{Ok(String), Empty, TooShort(usize)}` — ≥20 chars, Unicode-aware char counting, trim-before-count.
- `build_review_snapshot(Option<&deep_review>, &cfg)` — audit record builder. `score: None` when no deep review exists (distinct from `Some(0)` which means provider errored under strict policy).
- `startup_warnings(&cfg) -> Vec<String>` — pure; main.rs iterates and eprintln!s.

## Test plan

- [x] `cargo test -p dk-mcp --lib` — 65 passed, 0 failed
  - 6 env_parsing_tests (Task 2.1)
  - 5 verdict_mapping_tests (Task 2.2)
  - 1 review_gate_mock::tests (Task 2.3)
  - 5 run_background_review_tests (Task 2.4)
  - 11 evaluate_gate_tests (Tasks 2.5–2.7)
  - 5 force_validation_tests (Task 2.8)
  - 2 review_snapshot_tests (Task 2.8)
  - 3 startup_warnings_tests (Task 2.10)
  - 27 pre-existing dk-mcp tests
- [x] `cargo build -p dk-mcp` clean, 0 warnings
- [x] `cargo build -p dk-mcp --tests` clean, 0 warnings
- [ ] Manual smoke — `DKOD_CODE_REVIEW=1 DKOD_ANTHROPIC_API_KEY=sk-...` → `dk_submit` → wait → `dk_approve` succeeds with `[✓] deep review: N/5` prefix
- [ ] Manual smoke — cold path: `DKOD_CODE_REVIEW=1` with no key → startup log + `dk_approve` rejects with `gate_misconfigured`
- [ ] Manual smoke — force with 30-char reason → `⚠ force-approved` in output
- [ ] Manual smoke — force with 5-char reason → rejected
- [ ] Gate off (no env): behavior identical to today

## Scope notes

- Integration-test scaffolding (`McpTestHarness` in plan Task 2.4) was NOT built — does not exist in the repo, building it would be ~500+ lines of scaffolding out of scope. All logic is covered via pure-function unit tests with `MockReviewProvider`.
- `diff` and `context` passed to the review provider are EMPTY in this PR. Enriching them requires a new `GetChangesetDiff` RPC or a `FileList+FileRead` loop; tracked as a `// TODO:` in `server.rs` `dk_submit`.

## Known tradeoffs

- Gate-rejection responses use structured JSON (`{"error": "deep_review_pending", ...}`); force-validation failures use plain text (`"force requires override_reason (non-empty)"`) per the plan.
- Background review tasks are fire-and-forget; failure at any stage returns silently with a `tracing::debug!` log.