### PR TITLE
feat(review): default model to Opus 4.7 for both providers

### DIFF
--- a/crates/dk-mcp/src/review_gate.rs
+++ b/crates/dk-mcp/src/review_gate.rs
@@ -50,8 +50,8 @@ pub struct GateConfig {
     pub timeout: Duration,
     /// How provider errors and timeouts are handled — see [`BackoffPolicy`].
     pub backoff_policy: BackoffPolicy,
-    /// Optional provider-specific model override (e.g. `anthropic/claude-sonnet-4-5`).
-    /// When `None`, the provider implementation picks its default model.
+    /// Optional provider-specific model override (e.g. `anthropic/claude-opus-4.7` for OpenRouter,
+    /// `claude-opus-4-7` for Anthropic). When `None`, the provider implementation picks its default model.
     pub model: Option<String>,
 }
 

--- a/crates/dk-mcp/src/review_gate.rs
+++ b/crates/dk-mcp/src/review_gate.rs
@@ -1071,7 +1071,7 @@ mod review_snapshot_tests {
             min_score: 4,
             timeout: std::time::Duration::from_secs(180),
             backoff_policy: BackoffPolicy::Strict,
-            model: Some("claude-sonnet-4-6".into()),
+            model: Some("claude-opus-4-7".into()),
         }
     }
 
@@ -1090,7 +1090,7 @@ mod review_snapshot_tests {
         assert_eq!(s.threshold, Some(4));
         assert_eq!(s.findings_count, 3);
         assert_eq!(s.provider, "anthropic");
-        assert_eq!(s.model, "claude-sonnet-4-6");
+        assert_eq!(s.model, "claude-opus-4-7");
     }
 
     #[test]

--- a/crates/dk-protocol/tests/approve_proto_test.rs
+++ b/crates/dk-protocol/tests/approve_proto_test.rs
@@ -10,7 +10,7 @@ fn approve_request_has_override_reason_and_snapshot() {
             threshold: Some(4),
             findings_count: 3,
             provider: "openrouter".into(),
-            model: "anthropic/claude-sonnet-4".into(),
+            model: "anthropic/claude-opus-4.7".into(),
         }),
     };
     assert_eq!(
@@ -30,7 +30,7 @@ fn record_review_request_shape() {
         summary: Some("LGTM with minor warnings".into()),
         findings: vec![],
         provider: "anthropic".into(),
-        model: "claude-sonnet-4-6".into(),
+        model: "claude-opus-4-7".into(),
         duration_ms: 12345,
     };
     assert_eq!(req.tier, "deep");

--- a/crates/dk-runner/src/steps/agent_review/claude.rs
+++ b/crates/dk-runner/src/steps/agent_review/claude.rs
@@ -21,7 +21,7 @@ impl ClaudeReviewProvider {
         Ok(Self {
             client,
             api_key,
-            model: model.unwrap_or_else(|| "claude-sonnet-4-6".to_string()),
+            model: model.unwrap_or_else(|| "claude-opus-4-7".to_string()),
             max_tokens: max_tokens.unwrap_or(4096),
         })
     }

--- a/crates/dk-runner/src/steps/agent_review/openrouter.rs
+++ b/crates/dk-runner/src/steps/agent_review/openrouter.rs
@@ -26,7 +26,7 @@ impl OpenRouterReviewProvider {
         Ok(Self {
             client,
             api_key,
-            model: model.unwrap_or_else(|| "anthropic/claude-sonnet-4".to_string()),
+            model: model.unwrap_or_else(|| "anthropic/claude-opus-4.7".to_string()),
             max_tokens: max_tokens.unwrap_or(4096),
             base_url: base_url.unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string()),
         })


### PR DESCRIPTION
## Summary

Bumps the review providers' default model from Sonnet to Opus 4.7.

- Anthropic: \`claude-sonnet-4-6\` → \`claude-opus-4-7\`
- OpenRouter: \`anthropic/claude-sonnet-4\` → \`anthropic/claude-opus-4.7\` (note: OpenRouter uses \`.\` in the version, Anthropic API uses \`-\`)

Users who set \`DKOD_REVIEW_MODEL\` still override both. Audit snapshot + proto test fixtures updated to the new defaults for consistency.

Per the [Anthropic migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide): Opus 4.7 is the most capable Claude model, same \$5/\$25 MTok pricing as 4.6, drop-in compatible on existing prompts.

## Test plan
- [x] \`cargo test -p dk-mcp -p dk-runner -p dk-protocol --lib\` — 127 passed / 0 failed
- [x] \`cargo build -p dk-mcp\` clean
- [ ] CI green