### PR TITLE
feat(review): adaptive thinking + xhigh effort on Opus 4.7+

### DIFF
--- a/crates/dk-runner/src/steps/agent_review/claude.rs
+++ b/crates/dk-runner/src/steps/agent_review/claude.rs
@@ -21,8 +21,16 @@ impl ClaudeReviewProvider {
             .timeout(Duration::from_secs(120))
             .build()?;
         let effort = std::env::var("DKOD_REVIEW_EFFORT").unwrap_or_else(|_| "xhigh".to_string());
+        const VALID_EFFORTS: &[&str] = &["max", "xhigh", "high", "medium", "low"];
+        if !VALID_EFFORTS.contains(&effort.as_str()) {
+            anyhow::bail!(
+                "DKOD_REVIEW_EFFORT has invalid value {:?}; valid values: {}",
+                effort,
+                VALID_EFFORTS.join(", ")
+            );
+        }
         let adaptive_thinking = std::env::var("DKOD_REVIEW_ADAPTIVE_THINKING")
-            .map(|v| v != "0")
+            .map(|v| !matches!(v.to_lowercase().as_str(), "0" | "false" | "no" | "off"))
             .unwrap_or(true);
         Ok(Self {
             client,
@@ -43,10 +51,17 @@ impl ClaudeReviewProvider {
     }
 
     fn is_opus_4_7_or_later(&self) -> bool {
-        self.model.starts_with("claude-opus-4-7")
-            || self.model.starts_with("claude-opus-4-8")
-            || self.model.starts_with("claude-opus-4-9")
-            || self.model.starts_with("claude-opus-5")
+        let Some(rest) = self.model.strip_prefix("claude-opus-") else {
+            return false;
+        };
+        let mut parts = rest.split('-');
+        let major = parts.next().and_then(|s| s.parse::<u32>().ok());
+        let minor = parts.next().and_then(|s| s.parse::<u32>().ok());
+        match (major, minor) {
+            (Some(m), _) if m >= 5 => true,
+            (Some(4), Some(n)) if n >= 7 => true,
+            _ => false,
+        }
     }
 }
 
@@ -170,17 +185,22 @@ mod tests {
     fn is_opus_4_7_or_later_matches_new_models() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         clear_env();
-        let p = ClaudeReviewProvider::new("k".into(), Some("claude-opus-4-7".into()), None).unwrap();
-        assert!(p.is_opus_4_7_or_later());
-        let p = ClaudeReviewProvider::new(
-            "k".into(),
-            Some("claude-opus-4-7-20260101".into()),
-            None,
-        )
-        .unwrap();
-        assert!(p.is_opus_4_7_or_later());
-        let p = ClaudeReviewProvider::new("k".into(), Some("claude-opus-5".into()), None).unwrap();
-        assert!(p.is_opus_4_7_or_later());
+        for name in [
+            "claude-opus-4-7",
+            "claude-opus-4-7-20260101",
+            "claude-opus-4-8",
+            "claude-opus-4-9",
+            "claude-opus-4-10",
+            "claude-opus-4-11",
+            "claude-opus-4-15-preview",
+            "claude-opus-5",
+            "claude-opus-5-0",
+            "claude-opus-6",
+            "claude-opus-7-0-20270101",
+        ] {
+            let p = ClaudeReviewProvider::new("k".into(), Some(name.into()), None).unwrap();
+            assert!(p.is_opus_4_7_or_later(), "expected {name} to match");
+        }
     }
 
     #[test]
@@ -264,5 +284,45 @@ mod tests {
         let json = serde_json::to_string(&body).unwrap();
         assert!(!json.contains("\"thinking\""));
         assert!(!json.contains("\"output_config\""));
+    }
+
+    #[test]
+    fn invalid_effort_value_is_rejected() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env();
+        std::env::set_var("DKOD_REVIEW_EFFORT", "extreme");
+        let result = ClaudeReviewProvider::new("k".into(), None, None);
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected Err for invalid effort"),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("DKOD_REVIEW_EFFORT"), "msg was: {msg}");
+        assert!(msg.contains("extreme"), "msg was: {msg}");
+        clear_env();
+    }
+
+    #[test]
+    fn adaptive_thinking_disable_variants_case_insensitive() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for v in ["0", "false", "False", "FALSE", "no", "NO", "off", "Off"] {
+            clear_env();
+            std::env::set_var("DKOD_REVIEW_ADAPTIVE_THINKING", v);
+            let p = ClaudeReviewProvider::new("k".into(), None, None).unwrap();
+            assert!(!p.adaptive_thinking, "expected {v} to disable");
+        }
+        clear_env();
+    }
+
+    #[test]
+    fn adaptive_thinking_enable_variants() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for v in ["1", "true", "yes", "on", ""] {
+            clear_env();
+            std::env::set_var("DKOD_REVIEW_ADAPTIVE_THINKING", v);
+            let p = ClaudeReviewProvider::new("k".into(), None, None).unwrap();
+            assert!(p.adaptive_thinking, "expected {v:?} to leave thinking on");
+        }
+        clear_env();
     }
 }

--- a/crates/dk-runner/src/steps/agent_review/claude.rs
+++ b/crates/dk-runner/src/steps/agent_review/claude.rs
@@ -47,7 +47,12 @@ impl ClaudeReviewProvider {
             .or_else(|_| std::env::var("ANTHROPIC_API_KEY"))
             .ok()?;
         let model = std::env::var("DKOD_REVIEW_MODEL").ok();
-        Self::new(api_key, model, None).ok()
+        Self::new(api_key, model, None)
+            .map_err(|e| {
+                tracing::error!("ClaudeReviewProvider failed to initialise: {e:#}");
+                e
+            })
+            .ok()
     }
 
     fn is_opus_4_7_or_later(&self) -> bool {
@@ -323,6 +328,28 @@ mod tests {
             let p = ClaudeReviewProvider::new("k".into(), None, None).unwrap();
             assert!(p.adaptive_thinking, "expected {v:?} to leave thinking on");
         }
+        clear_env();
+    }
+
+    #[test]
+    fn from_env_returns_none_when_effort_invalid() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env();
+        std::env::set_var("ANTHROPIC_API_KEY", "k");
+        std::env::set_var("DKOD_REVIEW_EFFORT", "turbo");
+        // The invalid effort now causes new() to Err; from_env() logs via
+        // tracing::error and returns None instead of a silent, unloggable skip.
+        assert!(ClaudeReviewProvider::from_env().is_none());
+        clear_env();
+    }
+
+    #[test]
+    fn from_env_returns_some_when_valid() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env();
+        std::env::set_var("ANTHROPIC_API_KEY", "k");
+        // Defaults (xhigh effort, adaptive on) are valid.
+        assert!(ClaudeReviewProvider::from_env().is_some());
         clear_env();
     }
 }

--- a/crates/dk-runner/src/steps/agent_review/claude.rs
+++ b/crates/dk-runner/src/steps/agent_review/claude.rs
@@ -11,6 +11,8 @@ pub struct ClaudeReviewProvider {
     api_key: String,
     model: String,
     max_tokens: usize,
+    effort: String,
+    adaptive_thinking: bool,
 }
 
 impl ClaudeReviewProvider {
@@ -18,11 +20,17 @@ impl ClaudeReviewProvider {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(120))
             .build()?;
+        let effort = std::env::var("DKOD_REVIEW_EFFORT").unwrap_or_else(|_| "xhigh".to_string());
+        let adaptive_thinking = std::env::var("DKOD_REVIEW_ADAPTIVE_THINKING")
+            .map(|v| v != "0")
+            .unwrap_or(true);
         Ok(Self {
             client,
             api_key,
             model: model.unwrap_or_else(|| "claude-opus-4-7".to_string()),
-            max_tokens: max_tokens.unwrap_or(4096),
+            max_tokens: max_tokens.unwrap_or(64000),
+            effort,
+            adaptive_thinking,
         })
     }
 
@@ -33,6 +41,13 @@ impl ClaudeReviewProvider {
         let model = std::env::var("DKOD_REVIEW_MODEL").ok();
         Self::new(api_key, model, None).ok()
     }
+
+    fn is_opus_4_7_or_later(&self) -> bool {
+        self.model.starts_with("claude-opus-4-7")
+            || self.model.starts_with("claude-opus-4-8")
+            || self.model.starts_with("claude-opus-4-9")
+            || self.model.starts_with("claude-opus-5")
+    }
 }
 
 #[derive(Serialize)]
@@ -40,6 +55,20 @@ struct AnthropicRequest {
     model: String,
     max_tokens: usize,
     messages: Vec<Message>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<ThinkingConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_config: Option<OutputConfig>,
+}
+
+#[derive(Serialize)]
+struct ThinkingConfig {
+    r#type: String,
+}
+
+#[derive(Serialize)]
+struct OutputConfig {
+    effort: String,
 }
 
 #[derive(Serialize)]
@@ -78,6 +107,20 @@ impl ReviewProvider for ClaudeReviewProvider {
                     role: "user".to_string(),
                     content: prompt,
                 }],
+                thinking: if self.is_opus_4_7_or_later() && self.adaptive_thinking {
+                    Some(ThinkingConfig {
+                        r#type: "adaptive".to_string(),
+                    })
+                } else {
+                    None
+                },
+                output_config: if self.is_opus_4_7_or_later() {
+                    Some(OutputConfig {
+                        effort: self.effort.clone(),
+                    })
+                } else {
+                    None
+                },
             })
             .send()
             .await
@@ -100,5 +143,126 @@ impl ReviewProvider for ClaudeReviewProvider {
             .collect::<Vec<_>>()
             .join("");
         parse_review_response(&text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Serialize env-var mutation across tests in this module.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear_env() {
+        for k in [
+            "DKOD_REVIEW_EFFORT",
+            "DKOD_REVIEW_ADAPTIVE_THINKING",
+            "DKOD_REVIEW_MODEL",
+            "DKOD_REVIEW_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ] {
+            std::env::remove_var(k);
+        }
+    }
+
+    #[test]
+    fn is_opus_4_7_or_later_matches_new_models() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env();
+        let p = ClaudeReviewProvider::new("k".into(), Some("claude-opus-4-7".into()), None).unwrap();
+        assert!(p.is_opus_4_7_or_later());
+        let p = ClaudeReviewProvider::new(
+            "k".into(),
+            Some("claude-opus-4-7-20260101".into()),
+            None,
+        )
+        .unwrap();
+        assert!(p.is_opus_4_7_or_later());
+        let p = ClaudeReviewProvider::new("k".into(), Some("claude-opus-5".into()), None).unwrap();
+        assert!(p.is_opus_4_7_or_later());
+    }
+
+    #[test]
+    fn is_opus_4_7_or_later_rejects_older_models() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env();
+        let p = ClaudeReviewProvider::new("k".into(), Some("claude-opus-4-6".into()), None).unwrap();
+        assert!(!p.is_opus_4_7_or_later());
+        let p =
+            ClaudeReviewProvider::new("k".into(), Some("claude-sonnet-4-6".into()), None).unwrap();
+        assert!(!p.is_opus_4_7_or_later());
+    }
+
+    #[test]
+    fn defaults_effort_xhigh_and_adaptive_on() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env();
+        let p = ClaudeReviewProvider::new("k".into(), None, None).unwrap();
+        assert_eq!(p.effort, "xhigh");
+        assert!(p.adaptive_thinking);
+        assert_eq!(p.max_tokens, 64000);
+        assert_eq!(p.model, "claude-opus-4-7");
+    }
+
+    #[test]
+    fn effort_overridable_from_env() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env();
+        std::env::set_var("DKOD_REVIEW_EFFORT", "high");
+        let p = ClaudeReviewProvider::new("k".into(), None, None).unwrap();
+        assert_eq!(p.effort, "high");
+        clear_env();
+    }
+
+    #[test]
+    fn adaptive_thinking_disabled_by_env_zero() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env();
+        std::env::set_var("DKOD_REVIEW_ADAPTIVE_THINKING", "0");
+        let p = ClaudeReviewProvider::new("k".into(), None, None).unwrap();
+        assert!(!p.adaptive_thinking);
+        clear_env();
+    }
+
+    #[test]
+    fn request_body_includes_thinking_and_effort_for_opus_4_7() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env();
+        let p = ClaudeReviewProvider::new("k".into(), None, None).unwrap();
+        let body = AnthropicRequest {
+            model: p.model.clone(),
+            max_tokens: p.max_tokens,
+            messages: vec![Message {
+                role: "user".into(),
+                content: "hi".into(),
+            }],
+            thinking: Some(ThinkingConfig {
+                r#type: "adaptive".into(),
+            }),
+            output_config: Some(OutputConfig {
+                effort: p.effort.clone(),
+            }),
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(json.contains("\"thinking\":{\"type\":\"adaptive\"}"));
+        assert!(json.contains("\"output_config\":{\"effort\":\"xhigh\"}"));
+    }
+
+    #[test]
+    fn request_body_omits_thinking_and_effort_when_none() {
+        let body = AnthropicRequest {
+            model: "claude-opus-4-6".into(),
+            max_tokens: 4096,
+            messages: vec![Message {
+                role: "user".into(),
+                content: "hi".into(),
+            }],
+            thinking: None,
+            output_config: None,
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(!json.contains("\"thinking\""));
+        assert!(!json.contains("\"output_config\""));
     }
 }


### PR DESCRIPTION
## Summary

Opus 4.7 introduces **adaptive thinking** and the **effort** parameter, but they're off-by-default on the Messages API and the old extended-thinking shape returns 400. Opt ClaudeReviewProvider in automatically when the selected model is Opus 4.7+:

- `thinking: {type: "adaptive"}` — on by default; disable via `DKOD_REVIEW_ADAPTIVE_THINKING=0`
- `output_config: {effort: "xhigh"}` — Anthropic's recommended effort for coding/agentic use cases; override via `DKOD_REVIEW_EFFORT` (valid values: `max`, `xhigh`, `high`, `medium`, `low`)
- `max_tokens` default: `4096 → 64000` (Opus 4.7 supports up to 128k output)

Older models (Opus 4.6, Sonnet 4.x) omit both fields — the pre-4.7 Messages API returns 400 if you include them, and this PR is a drop-in for anyone still on those.

OpenRouter provider is **not** touched — it's OpenAI-compat and Anthropic's fields don't pass through. Separate follow-up if/when we want equivalent knobs there.

## Test plan
- [x] 7 new unit tests (`cargo test -p dk-runner --lib claude`) — model detection, env overrides, JSON body shape
- [x] Full regression: 134 passed across dk-runner/dk-mcp/dk-protocol
- [x] `cargo build -p dk-mcp` clean
- [ ] CI green

## Refs
- https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
- https://platform.claude.com/docs/en/build-with-claude/effort