### PR TITLE
feat(engine): default-on release-locks-at-submit (v0.3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "dk-agent-sdk"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "dk-protocol",
  "serde",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "dk-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "dk-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "dk-engine"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "dk-mcp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "dk-protocol"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "dk-runner"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "dk-server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ members = [
 ]
 
 [workspace.package]
-# 0.2.0 ships the release-locks-at-submit + STALE_OVERLAY feature set behind
-# DKOD_RELEASE_ON_SUBMIT=1. Bumping the pin in lockstep with the engine so
-# dk-mcp and dk-server can never drift once the testbed flips the flag on.
-version = "0.2.0"
+# 0.3.0 makes release-locks-at-submit + STALE_OVERLAY the default. Operators
+# can opt out with `DKOD_RELEASE_ON_SUBMIT=0` (the flag is preserved as a
+# rollback valve). 0.2.0 shipped the same code gated off; 0.3.0 flips the
+# default to on after the testbed validated zero regressions.
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/dkod-io/dkod-engine"
@@ -41,8 +42,8 @@ serde_yml = "0.0.12"
 rmp-serde = "1"
 
 # Internal crates
-dk-core = { path = "crates/dk-core", version = "0.2.0" }
-dk-engine = { path = "crates/dk-engine", version = "0.2.0" }
-dk-protocol = { path = "crates/dk-protocol", version = "0.2.0" }
-dk-runner = { path = "crates/dk-runner", version = "0.2.0" }
-dk-agent-sdk = { path = "crates/dk-agent-sdk", version = "0.2.0" }
+dk-core = { path = "crates/dk-core", version = "0.3.0" }
+dk-engine = { path = "crates/dk-engine", version = "0.3.0" }
+dk-protocol = { path = "crates/dk-protocol", version = "0.3.0" }
+dk-runner = { path = "crates/dk-runner", version = "0.3.0" }
+dk-agent-sdk = { path = "crates/dk-agent-sdk", version = "0.3.0" }

--- a/crates/dk-mcp/src/server.rs
+++ b/crates/dk-mcp/src/server.rs
@@ -1746,16 +1746,16 @@ impl DkodMcp {
             }
         }
 
-        // Behavior-change cue: on Accepted submits with the release-on-
-        // submit flag set, let agents know that symbol locks released on
-        // this call so other sessions watching for `symbol.lock.released`
-        // will unblock. Only shown when the flag is set in the MCP's own
-        // env, mirroring the engine, to avoid surprising operators running
-        // with the flag off.
+        // Behavior-change cue: on Accepted submits, let agents know that
+        // symbol locks released on this call so other sessions watching
+        // for `symbol.lock.released` will unblock. Default-on in the engine
+        // since 0.3.0; this mirrors that default and suppresses the note
+        // only when the operator has explicitly opted out by setting
+        // DKOD_RELEASE_ON_SUBMIT=0 in the MCP's own env.
         if response.status == crate::SubmitStatus::Accepted as i32
             && std::env::var("DKOD_RELEASE_ON_SUBMIT")
-                .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"))
-                .unwrap_or(false)
+                .map(|v| !matches!(v.as_str(), "0" | "false" | "FALSE" | "no"))
+                .unwrap_or(true)
         {
             text.push_str(
                 "\nLocks released on submit. Sessions waiting on \

--- a/crates/dk-protocol/src/file_write.rs
+++ b/crates/dk-protocol/src/file_write.rs
@@ -13,14 +13,21 @@ use crate::{ConflictWarning, FileWriteRequest, FileWriteResponse, SymbolChange};
 const STALE_OVERLAY_PREFIX: &str = "STALE_OVERLAY";
 
 /// Env flag for the release-locks-at-submit + STALE_OVERLAY behavior.
-/// Off by default in PR1; flipped in the testbed after zero-incident soak.
+///
+/// **Default: on.** Opt out with `DKOD_RELEASE_ON_SUBMIT=0` (also `false`,
+/// `FALSE`, `no`) if you need to revert to the old "release at merge"
+/// behavior. The flag is preserved as a rollback valve — flipping it off
+/// makes both the release-at-submit call site in `handle_submit` and the
+/// STALE_OVERLAY pre-write check in `handle_file_write` no-ops in a single
+/// place.
+///
 /// Shared with `submit.rs` so both call sites read the flag with identical
 /// semantics — preventing drift if one handler's parse logic is ever
 /// tweaked without the other.
 pub(crate) fn release_on_submit_enabled() -> bool {
     std::env::var("DKOD_RELEASE_ON_SUBMIT")
-        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"))
-        .unwrap_or(false)
+        .map(|v| !matches!(v.as_str(), "0" | "false" | "FALSE" | "no"))
+        .unwrap_or(true)
 }
 
 /// Handle a FileWrite RPC.

--- a/crates/dk-protocol/src/metrics.rs
+++ b/crates/dk-protocol/src/metrics.rs
@@ -9,7 +9,8 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Number of symbol locks released on `dk_submit` (flag-gated site).
-/// Zero while `DKOD_RELEASE_ON_SUBMIT=0`; strictly monotonic while on.
+/// Default-on; stays at zero only while an operator has explicitly opted
+/// out via `DKOD_RELEASE_ON_SUBMIT=0`, strictly monotonic otherwise.
 static LOCKS_RELEASED_ON_SUBMIT_TOTAL: AtomicU64 = AtomicU64::new(0);
 
 /// Number of `dk_file_write` calls rejected by the STALE_OVERLAY pre-check.

--- a/crates/dk-protocol/src/stale_overlay.rs
+++ b/crates/dk-protocol/src/stale_overlay.rs
@@ -1,12 +1,12 @@
 //! STALE_OVERLAY pre-write policy.
 //!
-//! When locks release at `dk_submit` (under `DKOD_RELEASE_ON_SUBMIT=1`), a
-//! waiting session can acquire a contested symbol seconds after the holder
-//! submits — far sooner than the old "locks release at merge" window. The
-//! recovery contract tells agents to re-read the file before writing, but if
-//! they skip that step their overlay is still pinned to `base_commit` and
-//! they will silently clobber the submitted (but not-yet-merged) overlay
-//! from the other session.
+//! Locks now release at `dk_submit` (default on; opt out with
+//! `DKOD_RELEASE_ON_SUBMIT=0`), so a waiting session can acquire a
+//! contested symbol seconds after the holder submits — far sooner than the
+//! old "locks release at merge" window. The recovery contract tells agents
+//! to re-read the file before writing, but if they skip that step their
+//! overlay is still pinned to `base_commit` and they will silently clobber
+//! the submitted (but not-yet-merged) overlay from the other session.
 //!
 //! This module is the engine-side backstop. It is deliberately pure so it
 //! can be unit-tested without Postgres; the live handler is a thin wrapper

--- a/crates/dk-protocol/src/submit.rs
+++ b/crates/dk-protocol/src/submit.rs
@@ -350,7 +350,7 @@ pub async fn handle_submit(
         event_id: uuid::Uuid::new_v4().to_string(),
     });
 
-    // ── Release-on-submit (DKOD_RELEASE_ON_SUBMIT) ──
+    // ── Release-on-submit (default on; opt out via DKOD_RELEASE_ON_SUBMIT=0) ──
     // Locks historically lived until `dk_merge`, which is 1–5 minutes after
     // this point when DKOD_CODE_REVIEW + the LAND fix-loop are enabled.
     // Releasing here collapses the hold window from minutes to the few
@@ -358,8 +358,8 @@ pub async fn handle_submit(
     // `dk_file_write`. The idempotent call in `handle_merge` still runs,
     // so crashed-before-merge sessions don't leave stranded locks.
     //
-    // Gated so PR1 ships flag-off and the testbed can flip it only after
-    // the STALE_OVERLAY backstop counter stays at zero.
+    // Flag preserved as a rollback valve — set DKOD_RELEASE_ON_SUBMIT=0 to
+    // revert to merge-time release without a code change.
     if release_on_submit_enabled() {
         let n = release_locks_and_emit(
             server,


### PR DESCRIPTION
## Summary

Flip `DKOD_RELEASE_ON_SUBMIT` default from off to on. The flag stays as a rollback valve — set `DKOD_RELEASE_ON_SUBMIT=0` (also `false` / `FALSE` / `no`) to revert to merge-time release without a code change.

## Why

PR #74 shipped the behavior gated off so the testbed could soak. Turning it on delivers the actual latency improvement — collapsing the symbol-lock hold window from **1–5 minutes** (release at `dk_merge`) down to **milliseconds** (release at `dk_submit`). The STALE_OVERLAY pre-write backstop rides with the same flag, so a session that skips the SYMBOL_LOCKED re-read step still can't silently clobber an in-flight overlay.

## Changes

- `release_on_submit_enabled()` default flipped: `unwrap_or(true)`, and the parse now checks for opt-out tokens (`"0"`/`"false"`/`"FALSE"`/`"no"`) instead of opt-in (`"1"`/`"true"`/...).
- MCP `dk_submit` cue text mirrors the flipped default: the "Locks released on submit" note shows by default, suppressed only when the operator explicitly opted out.
- Docstrings updated on the helper, the `dkod_engine_locks_released_on_submit_total` counter, the `stale_overlay` module, and the release-on-submit block in `handle_submit`.
- Workspace version `0.2.0 → 0.3.0` so dk-mcp / dk-server can't drift.

No test changes — the scoped tests exercise the ClaimTracker+EventBus layer and don't depend on the env-var parse.

## Rollback

`DKOD_RELEASE_ON_SUBMIT=0` — both the release-at-submit call site in `handle_submit` and the STALE_OVERLAY pre-write check in `handle_file_write` become no-ops in one place. The idempotent call in `handle_merge` continues to do the lock-release work exactly as before 0.2.0.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` (matches CI) — clean
- [x] `cargo test -p dk-protocol --lib stale_overlay` — 13/13 pass
- [x] `cargo test -p dk-protocol --test submit_releases_lock_test` — 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)