### PR TITLE
fix(engine): tolerate missing parent_changeset_id column in get()

### DIFF
--- a/crates/dk-engine/src/changeset.rs
+++ b/crates/dk-engine/src/changeset.rs
@@ -109,6 +109,14 @@ pub struct Changeset {
     /// Stacked-changeset parent. PR1 ships the column additively — nothing
     /// populates it and no consumer reads it. PR2 will set it at submit
     /// time and enforce merge-order on the chain.
+    ///
+    /// `#[sqlx(default)]` so `FromRow` tolerates a row that doesn't include
+    /// this column — lets the engine run against a DB where migration 015
+    /// hasn't been applied (hosted platforms manage schema independently).
+    /// Safe because no consumer reads the value yet. When PR2 starts
+    /// populating and reading it, add the column back to the SELECT in
+    /// `ChangesetStore::get` and drop this default.
+    #[sqlx(default)]
     pub parent_changeset_id: Option<Uuid>,
 }
 
@@ -254,13 +262,14 @@ impl ChangesetStore {
     }
 
     pub async fn get(&self, id: Uuid) -> dk_core::Result<Changeset> {
+        // `parent_changeset_id` is intentionally omitted here; see the field's
+        // doc comment. FromRow defaults the struct field to None.
         sqlx::query_as::<_, Changeset>(
             r#"SELECT id, repo_id, number, title, intent_summary,
                       source_branch, target_branch, state, reason,
                       session_id, agent_id, agent_name, author_id,
                       base_version, merged_version,
-                      created_at, updated_at, merged_at,
-                      parent_changeset_id
+                      created_at, updated_at, merged_at
                FROM changesets WHERE id = $1"#,
         )
         .bind(id)


### PR DESCRIPTION
## Summary

- Drops `parent_changeset_id` from the `SELECT` in `ChangesetStore::get()` and marks the struct field `#[sqlx(default)]`, so `FromRow` yields `None` when the column is absent.
- Unblocks `dk_merge` / `dk_verify` / the runner against DBs that don't yet have migration 015 applied — the exact failure the `/dkh` harness hit today (7 agents, all 7 merges blocked on `column "parent_changeset_id" does not exist`).
- Safe: the field's own doc comment (PR1) says nothing populates or reads it. PR2 will add the column back to the SELECT and drop the default when it starts consuming the value.

## Context

The workspace-eviction-recovery spec (`docs/superpowers/specs/2026-04-18-workspace-eviction-recovery-design.md`) already called out the platform DB drift as "Epic A — hosted-platform repo" and deferred it. This PR is the engine-side complement: make `get()` resilient so an out-of-sync platform schema stops cascading into blocked merges → evicted sessions → orphaned symbol locks.

## Test plan

- [x] `cargo check -p dk-engine -p dk-protocol -p dk-server -p dk-runner -p dk-mcp`
- [x] `cargo clippy -p dk-engine --lib -- -D warnings`
- [x] `cargo test -p dk-engine --test integration changeset_state_test` — 24 passed
- [x] `cargo test -p dk-engine --lib changeset` — 9 passed
- [x] CodeRabbit local review: 0 findings
- [ ] Integration tests against Postgres (run by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database query performance by adjusting how certain data fields are retrieved from the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->