### PR TITLE
fix(ci): derive release version from Cargo.toml, not last git tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,24 +113,47 @@ jobs:
         id: version
         run: |
           git fetch --tags
-          TAG_LATEST=$(git tag --list 'v*' --sort=-version:refname | head -1)
-          if [ -z "$TAG_LATEST" ]; then
-            TAG_LATEST="v0.0.0"
+
+          # Cargo.toml is the source of truth. Developers bump MAJOR or MINOR
+          # intentionally (e.g. PR #76 moved 0.2.0 -> 0.3.0); CI only patch-bumps
+          # within whatever major.minor line Cargo.toml is on.
+          #
+          # Previous logic computed NEXT = patch-bump(latest git tag), which
+          # silently downgraded Cargo.toml to the tag line. cargo-edit v0.13.9
+          # allowed the downgrade; v0.13.10 refuses it ("Cannot downgrade from
+          # 0.3.0 to 0.2.88"). Root-cause fix: derive NEXT from Cargo.toml so a
+          # manual major/minor bump is honored and the publish step never has
+          # to downgrade.
+          CARGO_VER=$(awk '/^\[workspace\.package\]/{f=1;next} /^\[/{f=0} f && /^version *=/ {gsub(/"/,"",$3); print $3; exit}' Cargo.toml)
+          if [ -z "$CARGO_VER" ]; then
+            # Fallback for alternate formatting: first top-level version line.
+            CARGO_VER=$(grep -E '^version[[:space:]]*=' Cargo.toml | head -1 | sed -E 's/version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
           fi
-          echo "Latest tag: $TAG_LATEST"
+          if [ -z "$CARGO_VER" ]; then
+            echo "::error::Could not read workspace version from Cargo.toml"
+            exit 1
+          fi
+          echo "Cargo.toml workspace version: $CARGO_VER"
 
-          VERSION="${TAG_LATEST#v}"
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-          PATCH=$(echo "$VERSION" | cut -d. -f3)
-          NEXT_PATCH=$((PATCH + 1))
-          NEXT_VERSION="v${MAJOR}.${MINOR}.${NEXT_PATCH}"
+          MAJOR=$(echo "$CARGO_VER" | cut -d. -f1)
+          MINOR=$(echo "$CARGO_VER" | cut -d. -f2)
+          PATCH=$(echo "$CARGO_VER" | cut -d. -f3)
 
-          while git rev-parse "$NEXT_VERSION" >/dev/null 2>&1; do
-            echo "Tag $NEXT_VERSION already exists, bumping again..."
-            NEXT_PATCH=$((NEXT_PATCH + 1))
+          CARGO_TAG="v${CARGO_VER}"
+          if git rev-parse "$CARGO_TAG" >/dev/null 2>&1; then
+            # Cargo.toml version already released -- patch-bump for this run.
+            NEXT_PATCH=$((PATCH + 1))
             NEXT_VERSION="v${MAJOR}.${MINOR}.${NEXT_PATCH}"
-          done
+            while git rev-parse "$NEXT_VERSION" >/dev/null 2>&1; do
+              echo "Tag $NEXT_VERSION already exists, bumping again..."
+              NEXT_PATCH=$((NEXT_PATCH + 1))
+              NEXT_VERSION="v${MAJOR}.${MINOR}.${NEXT_PATCH}"
+            done
+          else
+            # First release of this Cargo.toml version -- tag as-is so a
+            # deliberate 0.2.0 -> 0.3.0 bump in Cargo.toml produces v0.3.0.
+            NEXT_VERSION="$CARGO_TAG"
+          fi
 
           echo "version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
           echo "Next version: $NEXT_VERSION"


### PR DESCRIPTION
## Summary

Fixes the recurring `Cannot downgrade from 0.3.0 to 0.2.88` failure in the publish job that's been failing since PR #76 landed (example run: https://github.com/dkod-io/dkod-engine/actions/runs/24719156889/job/72305516419).

## Root cause

The `Compute next version` step computed `NEXT = patch-bump(latest_git_tag)`, then the `publish` job ran `cargo set-version --workspace "$NEXT"` to align Cargo.toml for the crates.io publish.

That logic ignored Cargo.toml entirely. PR #76 intentionally bumped the workspace from `0.2.0` → `0.3.0` to signal the release-locks-at-submit default flip, but every merge since has attempted to silently revert the workspace back to `0.2.8x` at publish time.

`cargo-edit` v0.13.9 tolerated that downgrade (so tags `v0.2.85`..`v0.2.87` got created even though Cargo.toml on `main` stayed at `0.3.0`). `cargo-edit` v0.13.10 (released this week) refuses it explicitly — that's why the latest merge surfaces a hard failure instead of silently undoing the version bump.

## Fix

Make `Cargo.toml` the source of truth in the `Compute next version` step:

- If `v{Cargo.toml version}` is not yet a tag, use it directly. A deliberate major/minor bump in `Cargo.toml` (e.g. `0.2.0` → `0.3.0`) now produces `v0.3.0`.
- Otherwise patch-bump from the Cargo.toml version, skipping existing tags until we find an unused one.

Downstream effect on the publish step: `cargo set-version --workspace "$NEXT"` becomes either a no-op or a valid patch upgrade, so the cargo-edit v0.13.10 guard is satisfied by construction.

## Expected behavior after merge

- First run on current `main` (Cargo.toml `0.3.0`, tags up to `v0.2.87`): tags **v0.3.0**, publishes crates at 0.3.0. This is the version that was always intended by PR #76.
- Next run without a manual Cargo.toml change: patch-bumps to **v0.3.1**, etc.

## Test plan

- [ ] CI on this PR runs through `version` + `build` + `release` without error.
- [ ] After merge, the auto-tag step tags `v0.3.0` and the `Publish to crates.io` job no longer downgrades.
- [ ] Subsequent merges patch-bump within the 0.3.x line as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD release version computation to derive from the project manifest instead of git history, improving consistency and reliability of version tag generation during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->